### PR TITLE
CDITCK-307 Add missing tests for BeforeBeanDiscovery event

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/lifecycle/ExtensionsTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/lifecycle/ExtensionsTest.java
@@ -49,21 +49,12 @@ public class ExtensionsTest extends AbstractTest {
     }
 
     @Test
-    @SpecAssertions({ @SpecAssertion(section = BBD, id = "a"), @SpecAssertion(section = INITIALIZATION, id = "b"),
-            @SpecAssertion(section = INITIALIZATION, id = "c") })
+    @SpecAssertions({
+        @SpecAssertion(section = BBD, id = "a"),
+        @SpecAssertion(section = INITIALIZATION, id = "b"),
+        @SpecAssertion(section = INITIALIZATION, id = "c")})
     public void testBeforeBeanDiscoveryEventIsCalled() {
         assertTrue(BeforeBeanDiscoveryObserver.isObserved());
-    }
-
-    @SuppressWarnings("serial")
-    @Test
-    @SpecAssertion(section = BBD, id = "ab")
-    public void testAddingBindingType() {
-        assertTrue(BeforeBeanDiscoveryObserver.isObserved());
-        assertEquals(getBeans(Alligator.class).size(), 0);
-        assertEquals(getBeans(Alligator.class, new AnnotationLiteral<Tame>() {
-        }).size(), 1);
-        assertTrue(getCurrentManager().isQualifier(Tame.class));
     }
 
     @Test
@@ -75,4 +66,46 @@ public class ExtensionsTest extends AbstractTest {
         assertTrue(bean.getScope().equals(EpochScoped.class));
     }
 
+    @SuppressWarnings("serial")
+    @Test
+    @SpecAssertion(section = BBD, id = "ab")
+    public void testAddingQualifierByClass() {
+        assertTrue(BeforeBeanDiscoveryObserver.isObserved());
+        assertEquals(getBeans(Alligator.class).size(), 0);
+        assertEquals(getBeans(Alligator.class, new AnnotationLiteral<Tame>() {
+        }).size(), 1);
+        assertTrue(getCurrentManager().isQualifier(Tame.class));
+    }
+
+    @Test
+    @SpecAssertion(section = BBD, id = "aba")
+    public void testAddingQualifierByAnnotatedType() {
+        assertTrue(BeforeBeanDiscoveryObserver.isObserved());
+
+        // @Skill#level should be ignored
+        assertEquals(beanManager.getBeans(Programmer.class, new SkillLiteral() {
+            @Override
+            public String language() {
+                return "Java";
+            }
+
+            @Override
+            public String level() {
+                return "whatever";
+            }
+        }), 1);
+
+        // there should be no @Skill(language="C++")Programmer
+        assertEquals(beanManager.getBeans(Programmer.class, new SkillLiteral() {
+            @Override
+            public String language() {
+                return "C++";
+            }
+
+            @Override
+            public String level() {
+                return "guru";
+            }
+        }), 0);
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/lifecycle/Programmer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/lifecycle/Programmer.java
@@ -1,0 +1,21 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.cdi.tck.tests.deployment.lifecycle;
+
+@Skill(language = "Java", level = "guru")
+public class Programmer {
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/lifecycle/Skill.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/lifecycle/Skill.java
@@ -1,0 +1,32 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.cdi.tck.tests.deployment.lifecycle;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import java.lang.annotation.Retention;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import java.lang.annotation.Target;
+
+@Retention(RUNTIME)
+@Target({METHOD, FIELD, PARAMETER, TYPE})
+public @interface Skill {
+    String language();
+    String level();
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/lifecycle/SkillLiteral.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/lifecycle/SkillLiteral.java
@@ -1,0 +1,22 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.cdi.tck.tests.deployment.lifecycle;
+
+import javax.enterprise.util.AnnotationLiteral;
+
+public abstract class SkillLiteral extends AnnotationLiteral<Skill> implements Skill {
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/interceptors/InterceptorExtensionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/interceptors/InterceptorExtensionTest.java
@@ -57,12 +57,12 @@ public class InterceptorExtensionTest extends AbstractTest {
 
         return new WebArchiveBuilder()
                 .withTestClass(InterceptorExtensionTest.class)
-                .withClasses(Marathon.class, NumberSource.class)
-                .withLibrary(IncrementingInterceptor.class, LifecycleInterceptor.class, FullMarathon.class, Incremented.class,
+                .withClasses(Marathon.class, NumberSource.class, WordSource.class)
+                .withLibrary(SuffixingInterceptor.class, IncrementingInterceptor.class, LifecycleInterceptor.class, Suffixed.class, FullMarathon.class, Incremented.class,
                         InterceptorExtension.class)
                 .withBeansXml(
                         Descriptors.create(BeansDescriptor.class).createInterceptors()
-                                .clazz(IncrementingInterceptor.class.getName(), LifecycleInterceptor.class.getName()).up())
+                                .clazz(SuffixingInterceptor.class.getName(), IncrementingInterceptor.class.getName(), LifecycleInterceptor.class.getName()).up())
                 .build();
     }
 
@@ -71,12 +71,15 @@ public class InterceptorExtensionTest extends AbstractTest {
 
     @Inject
     private NumberSource numberSource;
+    
+    @Inject
+    private WordSource wordSource;
 
     @Test
     @SpecAssertions({ @SpecAssertion(section = INIT_EVENTS, id = "b"), @SpecAssertion(section = INIT_EVENTS, id = "bb"),
             @SpecAssertion(section = BBD, id = "ae") })
-    public void testInterceptorCalled() {
-        assertEquals(2, numberSource.value());
+    public void testInterceptorAddedByClass() {
+        assertEquals(numberSource.value(), 2);
         assertTrue(IncrementingInterceptor.isDoAroundCalled());
     }
 
@@ -91,9 +94,18 @@ public class InterceptorExtensionTest extends AbstractTest {
         Marathon marathon = (Marathon) bean.create(creationalContext);
 
         assertTrue(LifecycleInterceptor.isPostConstructCalled());
-        assertEquals(42, marathon.getLength());
+        assertEquals(marathon.getLength(), 42);
         bean.destroy(marathon, creationalContext);
         assertTrue(LifecycleInterceptor.isPreDestroyCalled());
     }
-
+    
+    @Test
+    @SpecAssertions({ @SpecAssertion(section = INIT_EVENTS, id = "b"), @SpecAssertion(section = INIT_EVENTS, id = "bb"),
+            @SpecAssertion(section = BBD, id = "aea") })
+    public void testInterceptorAddedByAnnotatedType() {
+        assertEquals(wordSource.getWord(), WordSource.word);
+        assertEquals(wordSource.getWordWithSuffix(), WordSource.wordWithSuffix);
+        assertTrue(SuffixingInterceptor.isDoAroundCalled());
+    }
+    
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/interceptors/Suffixed.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/interceptors/Suffixed.java
@@ -1,0 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.cdi.tck.tests.extensions.interceptors;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(value = {ElementType.TYPE, ElementType.METHOD})
+public @interface Suffixed {
+
+   String value() default "ly";
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/interceptors/SuffixingInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/interceptors/SuffixingInterceptor.java
@@ -1,0 +1,42 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.cdi.tck.tests.extensions.interceptors;
+
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InvocationContext;
+
+/**
+ * Interceptor that adds suffix -ly to a word
+ */
+@Suffixed
+@Interceptor
+public class SuffixingInterceptor {
+    private static boolean doAroundCalled = false;
+
+    @AroundInvoke
+    public Object doAround(InvocationContext context) throws Exception {
+        doAroundCalled = true;
+        String result = (String) context.proceed();
+        String suffix = context.getMethod().getAnnotation(Suffixed.class).value();
+        return result + suffix;
+    }
+
+    public static boolean isDoAroundCalled() {
+        return doAroundCalled;
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/interceptors/WordSource.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/interceptors/WordSource.java
@@ -1,0 +1,33 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.cdi.tck.tests.extensions.interceptors;
+
+public class WordSource {
+    
+    public static final String word = "awesome";
+    public static final String suffix = "ness";
+    public static final String wordWithSuffix = word + suffix;
+    
+    @Suffixed(suffix)
+    public String getWordWithSuffix() {
+        return word;
+    }
+    
+    public String getWord() {
+        return word;
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/registration/Beanie.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/registration/Beanie.java
@@ -1,0 +1,26 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.cdi.tck.tests.extensions.registration;
+
+/**
+ *
+ * @author rsmeral
+ */
+@BeanieType("basic")
+public class Beanie {
+    
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/registration/BeanieType.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/registration/BeanieType.java
@@ -1,0 +1,30 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.cdi.tck.tests.extensions.registration;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.inject.Qualifier;
+
+@Qualifier
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface BeanieType {
+    String value();
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/registration/BeanieTypeLiteral.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/registration/BeanieTypeLiteral.java
@@ -1,0 +1,22 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.cdi.tck.tests.extensions.registration;
+
+import javax.enterprise.util.AnnotationLiteral;
+
+public abstract class BeanieTypeLiteral extends AnnotationLiteral<BeanieType> implements BeanieType {
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/registration/DuplicateIdentifiedAnnotatedTypeExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/registration/DuplicateIdentifiedAnnotatedTypeExtension.java
@@ -1,0 +1,67 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.cdi.tck.tests.extensions.registration;
+
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.spi.AnnotatedType;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.BeforeBeanDiscovery;
+import org.jboss.cdi.tck.util.AddForwardingAnnotatedTypeAction;
+
+public class DuplicateIdentifiedAnnotatedTypeExtension {
+
+    public void registerBeans(@Observes BeforeBeanDiscovery event, final BeanManager bm) {
+        
+        final String nonUniqueId = DuplicateIdentifiedAnnotatedTypeExtension.class.getName() + "someNonUniqueId";
+        
+        // add BeanClassToRegister and Beanie with the same id
+        
+        new AddForwardingAnnotatedTypeAction<BeanClassToRegister>() {
+            @Override
+            public String getId() {
+                return nonUniqueId;
+            }
+
+            @Override
+            public String getBaseId() {
+                return DuplicateIdentifiedAnnotatedTypeExtension.class.getName();
+            }
+
+            @Override
+            public AnnotatedType<BeanClassToRegister> delegate() {
+                return bm.createAnnotatedType(BeanClassToRegister.class);
+            }
+        }.perform(event);
+        
+        new AddForwardingAnnotatedTypeAction<Beanie>() {
+            @Override
+            public String getId() {
+                return nonUniqueId;
+            }
+
+            @Override
+            public String getBaseId() {
+                return DuplicateIdentifiedAnnotatedTypeExtension.class.getName();
+            }
+
+            @Override
+            public AnnotatedType<Beanie> delegate() {
+                return bm.createAnnotatedType(Beanie.class);
+            }
+        }.perform(event);
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/registration/DuplicateIdentifiedAnnotatedTypeTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/registration/DuplicateIdentifiedAnnotatedTypeTest.java
@@ -1,0 +1,38 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.cdi.tck.tests.extensions.registration;
+
+import javax.enterprise.inject.spi.DeploymentException;
+import static org.jboss.cdi.tck.cdi.Sections.BEAN_ARCHIVE;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.ShouldThrowException;
+import org.jboss.cdi.tck.AbstractTest;
+import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.test.audit.annotations.SpecAssertion;
+
+public class DuplicateIdentifiedAnnotatedTypeTest extends AbstractTest {
+
+    @Deployment
+    @ShouldThrowException(DeploymentException.class)
+    @SpecAssertion(section = BEAN_ARCHIVE, id = "afb")
+    public static WebArchive createTestArchive() {
+        return new WebArchiveBuilder().withTestClass(DuplicateIdentifiedAnnotatedTypeTest.class)
+                .withLibrary(BeanClassToRegister.class, Beanie.class, DuplicateIdentifiedAnnotatedTypeExtension.class).build();
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/registration/TwoBeansOneClassExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/registration/TwoBeansOneClassExtension.java
@@ -1,0 +1,67 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.cdi.tck.tests.extensions.registration;
+
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.spi.AnnotatedType;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.BeforeBeanDiscovery;
+import javax.enterprise.inject.spi.Extension;
+
+import org.jboss.cdi.tck.util.AddForwardingAnnotatedTypeAction;
+import org.jboss.cdi.tck.util.annotated.AnnotatedTypeWrapper;
+
+// This test extension expects that AddForwardingAnnotatedTypeAction distinguishes 
+// annotated types by more that just the baseId and delegate class
+public class TwoBeansOneClassExtension implements Extension {
+    public void registerBeans(@Observes BeforeBeanDiscovery event, final BeanManager bm) {
+
+        // add basic Beanie
+        new AddForwardingAnnotatedTypeAction<Beanie>() {
+
+            @Override
+            public String getBaseId() {
+                return TwoBeansOneClassExtension.class.getName();
+            }
+
+            @Override
+            public AnnotatedType<Beanie> delegate() {
+                return bm.createAnnotatedType(Beanie.class);
+            }
+        }.perform(event);
+        
+        // add @BeanieType("propeller")Beanie
+        new AddForwardingAnnotatedTypeAction<Beanie>() {
+
+            @Override
+            public String getBaseId() {
+                return TwoBeansOneClassExtension.class.getName();
+            }
+
+            @Override
+            public AnnotatedType<Beanie> delegate() {
+                return new AnnotatedTypeWrapper<Beanie>(bm.createAnnotatedType(Beanie.class), false, new BeanieTypeLiteral() {
+
+                    @Override
+                    public String value() {
+                        return "propeller";
+                    }
+                });
+            }
+        }.perform(event);
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/registration/TwoBeansOneClassTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/registration/TwoBeansOneClassTest.java
@@ -1,0 +1,65 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.cdi.tck.tests.extensions.registration;
+
+import javax.enterprise.inject.spi.DeploymentException;
+import static org.jboss.cdi.tck.cdi.Sections.BBD;
+import static org.jboss.cdi.tck.cdi.Sections.BEAN_ARCHIVE;
+import static org.jboss.cdi.tck.cdi.Sections.INIT_EVENTS;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.ShouldThrowException;
+import org.jboss.cdi.tck.AbstractTest;
+import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.test.audit.annotations.SpecAssertion;
+import org.jboss.test.audit.annotations.SpecAssertions;
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertEquals;
+
+public class TwoBeansOneClassTest extends AbstractTest {
+
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return new WebArchiveBuilder().withTestClass(TwoBeansOneClassTest.class)
+                .withLibrary(TwoBeansOneClassExtension.class, Beanie.class, BeanieType.class, BeanieTypeLiteral.class).build();
+    }
+
+    @Test
+    @SpecAssertions({
+        @SpecAssertion(section = INIT_EVENTS, id = "b"),
+        @SpecAssertion(section = INIT_EVENTS, id = "bb"),
+        @SpecAssertion(section = BBD, id = "af"),
+        @SpecAssertion(section = BEAN_ARCHIVE, id = "f"),
+        @SpecAssertion(section = BEAN_ARCHIVE, id = "afa")})
+    public void testTwoBeansWithOneBaseClass() {
+        assertEquals(beanManager.getBeans(Beanie.class), 0);
+        assertEquals(beanManager.getBeans(Beanie.class, new BeanieTypeLiteral() {
+            @Override
+            public String value() {
+                return "basic";
+            }
+        }), 1);
+
+        assertEquals(beanManager.getBeans(Beanie.class, new BeanieTypeLiteral() {
+            @Override
+            public String value() {
+                return "propeller";
+            }
+        }), 1);
+    }
+}


### PR DESCRIPTION
Also renamed a few existing methods and swapped order of some assertEquals to the correct (actual, expected) to make the test classes cleaner
