### PR TITLE
CDITCK-365

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/impl/testng/ConfigurationLoggingListener.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/impl/testng/ConfigurationLoggingListener.java
@@ -1,0 +1,58 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.cdi.tck.impl.testng;
+
+import java.io.IOException;
+import java.util.logging.FileHandler;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
+
+import org.jboss.cdi.tck.api.Configuration;
+import org.jboss.cdi.tck.impl.ConfigurationFactory;
+import org.testng.ISuite;
+import org.testng.ISuiteListener;
+
+public class ConfigurationLoggingListener implements ISuiteListener {
+
+    private static final String CONFIGURATION_FILE_PATH = "target/cdi-tck-configuration.txt";
+    private final Logger logger = Logger.getLogger(ConfigurationLoggingListener.class.getName());
+
+    @Override
+    public void onStart(ISuite suite) {
+        try {
+            FileHandler fh = new FileHandler(CONFIGURATION_FILE_PATH);
+            fh.setFormatter(new SimpleFormatter());
+            logger.addHandler(fh);
+        } catch (SecurityException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        logger.log(Level.INFO, "CDI-TCK Implementation version: {0}", Package.getPackage("org.jboss.cdi.tck.impl.testng").getImplementationVersion());
+        logger.log(Level.INFO, "CDI-TCK Specification version: {0}", Package.getPackage("org.jboss.cdi.tck.impl.testng").getSpecificationVersion());
+        Configuration conf = ConfigurationFactory.get();
+        logger.log(Level.INFO, conf.toString());
+    }
+
+    @Override
+    public void onFinish(ISuite suite) {
+
+    }
+
+}

--- a/impl/src/main/resources/tck-tests.xml
+++ b/impl/src/main/resources/tck-tests.xml
@@ -5,6 +5,7 @@
         <!-- Required - avoid randomly mixed test method execution -->
         <listener class-name="org.jboss.cdi.tck.impl.testng.SingleTestClassMethodInterceptor" />
         <!-- Optional - intended for debug purpose only -->
+        <listener class-name="org.jboss.cdi.tck.impl.testng.ConfigurationLoggingListener"/> 
         <listener class-name="org.jboss.cdi.tck.impl.testng.ProgressLoggingTestListener"/>
         <!-- Optional - it's recommended to disable the default JUnit XML reporter -->
         <listener class-name="org.testng.reporters.SuiteHTMLReporter"/>


### PR DESCRIPTION
Creating and logging configuration to file. Needed change in jboss-tck-runner also
Example of such file is:

Aug 28, 2013 12:37:12 PM org.jboss.cdi.tck.impl.testng.ConfigurationLoggingListener onStart
INFO: CDI-TCK Implementation version: 20130828-1218
Aug 28, 2013 12:37:12 PM org.jboss.cdi.tck.impl.testng.ConfigurationLoggingListener onStart
INFO: CDI-TCK Specification version: 1.2.0.SNAPSHOT
Aug 28, 2013 12:37:12 PM org.jboss.cdi.tck.impl.testng.ConfigurationLoggingListener onStart
## INFO: JSR 346 TCK Configuration

```
Beans: org.jboss.weld.tck.BeansImpl@298aa724
Contexts: org.jboss.weld.tck.ContextsImpl@4de341ca
EL: org.jboss.weld.tck.ELImpl@2f45cb9
Library dir: target/dependency/lib
Test DS: java:jboss/datasources/ExampleDS
Test JMS connection factory: java:/ConnectionFactory
Test JMS queue: java:/queue/test
Test JMS topic: java:/topic/test
```
