### PR TITLE
CDITCK-372 

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/Number.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/Number.java
@@ -1,0 +1,19 @@
+package org.jboss.cdi.tck.tests.implementation.producer.method.definition;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.inject.Qualifier;
+
+@Target({ TYPE, METHOD, PARAMETER, FIELD })
+@Retention(RUNTIME)
+@Qualifier
+public @interface Number {
+
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/ProducerMethodDefinitionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/ProducerMethodDefinitionTest.java
@@ -67,6 +67,8 @@ public class ProducerMethodDefinitionTest extends AbstractTest {
     };
     private static final Annotation DEADLIEST_LITERAL = new AnnotationLiteral<Deadliest>() {
     };
+    private static final Annotation NUMBER_LITERAL = new AnnotationLiteral<Number>() {
+    };
 
     @Deployment
     public static WebArchive createTestArchive() {
@@ -142,7 +144,7 @@ public class ProducerMethodDefinitionTest extends AbstractTest {
     @Test
     @SpecAssertion(section = PRODUCER_METHOD_TYPES, id = "ba")
     public void testApiTypeForPrimitiveReturn() throws Exception {
-        assert getBeans(Integer.class).size() == 1;
+        assert getBeans(Integer.class,NUMBER_LITERAL).size() == 1;
         Bean<Integer> integer = getBeans(Integer.class).iterator().next();
         assert integer.getTypes().size() == 2;
         assert integer.getTypes().contains(int.class);

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/SpiderProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/SpiderProducer.java
@@ -51,6 +51,7 @@ public class SpiderProducer {
         return new WolfSpider();
     }
 
+    @Number
     @Produces
     public int getWolfSpiderSize() {
         return 4;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/ResolutionByTypeTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/ResolutionByTypeTest.java
@@ -40,7 +40,6 @@ import javax.enterprise.util.TypeLiteral;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
-import org.jboss.cdi.tck.literals.AnyLiteral;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.test.audit.annotations.SpecAssertion;
@@ -63,6 +62,8 @@ public class ResolutionByTypeTest extends AbstractTest {
     private static final Annotation TAME = new AnnotationLiteral<Tame>() {
     };
     private static final Annotation WILD = new AnnotationLiteral<Wild>() {
+    };
+    private static final Annotation NUMBER = new AnnotationLiteral<Number>() {
     };
 
     @Deployment
@@ -122,8 +123,8 @@ public class ResolutionByTypeTest extends AbstractTest {
             @SpecAssertion(section = MULTIPLE_QUALIFIERS, id = "c"), @SpecAssertion(section = LEGAL_BEAN_TYPES, id = "j") })
     public void testResolveByTypeWithPrimitives() {
 
-        assertEquals(getBeans(Double.class, AnyLiteral.INSTANCE).size(), 2);
-        assertEquals(getBeans(double.class, AnyLiteral.INSTANCE).size(), 2);
+        assertEquals(getBeans(Double.class, NUMBER).size(), 2);
+        assertEquals(getBeans(double.class, NUMBER).size(), 2);
 
         Double min = getContextualReference(Double.class, new AnnotationLiteral<Min>() {
         });


### PR DESCRIPTION
ResolutionByTypeTest.testResolveByTypeWithPrimitives() does not tolerate built-in beans.

Tests getting beans by primitive type: 
1.ResolutionByTypeTest.testResolveByTypeWithPrimitives() 
2.ProducerMethodDefinitionTest.testApiTypeForPrimitiveReturn()
