### PR TITLE
Fixed built-in object observers

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/bindingTypes/DiscerningObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/bindingTypes/DiscerningObserver.java
@@ -18,18 +18,17 @@ package org.jboss.cdi.tck.tests.event.bindingTypes;
 
 import javax.enterprise.context.RequestScoped;
 import javax.enterprise.event.Observes;
-import javax.enterprise.inject.Any;
 
 @RequestScoped
 class DiscerningObserver {
     private int numTimesAnyBindingTypeEventObserved = 0;
     private int numTimesNonRuntimeBindingTypeObserved = 0;
 
-    public void observeAny(@Observes @Any String event) {
+    public void observeAny(@Observes @Extra String event) {
         numTimesAnyBindingTypeEventObserved++;
     }
 
-    public void observeNonRuntime(@Observes @Any @NonRuntimeBindingType String event) {
+    public void observeNonRuntime(@Observes @Extra @NonRuntimeBindingType String event) {
         numTimesNonRuntimeBindingTypeObserved++;
     }
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/bindingTypes/EventEmitter.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/bindingTypes/EventEmitter.java
@@ -17,16 +17,15 @@
 package org.jboss.cdi.tck.tests.event.bindingTypes;
 
 import javax.enterprise.event.Event;
-import javax.enterprise.inject.Any;
 import javax.inject.Inject;
 
 public class EventEmitter {
     @Inject
-    @Any
+    @Extra
     Event<String> stringEvent;
 
     @Inject
-    @Any
+    @Extra
     @NonRuntimeBindingType
     Event<String> stringEventWithAnyAndNonRuntimeBindingType;
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/bindingTypes/Extra.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/bindingTypes/Extra.java
@@ -1,0 +1,20 @@
+package org.jboss.cdi.tck.tests.event.bindingTypes;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.inject.Qualifier;
+
+@Target({ TYPE, METHOD, PARAMETER, FIELD })
+@Retention(RUNTIME)
+@Documented
+@Qualifier
+public @interface Extra {
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/eventTypes/EventTypesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/eventTypes/EventTypesTest.java
@@ -21,6 +21,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 import javax.enterprise.event.Event;
+import javax.enterprise.util.AnnotationLiteral;
 import javax.inject.Inject;
 
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -39,6 +40,9 @@ import org.testng.annotations.Test;
  */
 @SpecVersion(spec = "cdi", version = "1.1 Final Release")
 public class EventTypesTest extends AbstractTest {
+
+    private AnnotationLiteral<Extra> extraLiteral = new AnnotationLiteral<Extra>() {
+    };
 
     @Deployment
     public static WebArchive createTestArchive() {
@@ -76,7 +80,7 @@ public class EventTypesTest extends AbstractTest {
         assert listener.getObjectsFired().size() == 3;
         assert listener.getObjectsFired().get(2) == b;
         // boxed primitive
-        getCurrentManager().fireEvent(1);
+        getCurrentManager().fireEvent(1, extraLiteral);
         assert listener.getObjectsFired().size() == 4;
         assert listener.getObjectsFired().get(3).equals(1);
     }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/eventTypes/Extra.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/eventTypes/Extra.java
@@ -1,0 +1,20 @@
+package org.jboss.cdi.tck.tests.event.eventTypes;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.inject.Qualifier;
+
+@Target({ TYPE, METHOD, PARAMETER, FIELD })
+@Retention(RUNTIME)
+@Documented
+@Qualifier
+public @interface Extra {
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/eventTypes/Listener.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/eventTypes/Listener.java
@@ -27,7 +27,7 @@ import javax.enterprise.inject.Any;
 class Listener {
     List<Object> objectsFired = new ArrayList<Object>();
 
-    public void registerNumberFired(@Observes @Any Integer i) {
+    public void registerNumberFired(@Observes @Extra Integer i) {
         objectsFired.add(i);
     }
 


### PR DESCRIPTION
1x String
1x Integer
the others didn't need a change as the observer was not used.
