### PR TITLE
Add @ConversationScoped beans to conversation tests

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/conversation/determination/Duck.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/conversation/determination/Duck.java
@@ -1,0 +1,28 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.cdi.tck.tests.context.conversation.determination;
+
+import java.io.Serializable;
+
+import javax.enterprise.context.ConversationScoped;
+
+@ConversationScoped
+public class Duck implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/conversation/Duck.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/conversation/Duck.java
@@ -1,0 +1,28 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.cdi.tck.tests.decorators.builtin.conversation;
+
+import java.io.Serializable;
+
+import javax.enterprise.context.ConversationScoped;
+
+@ConversationScoped
+public class Duck implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+}


### PR DESCRIPTION
Each test for conversations should have at least one @ConversationScoped bean. This allows an implementation to perform optimizations when the conversation context is not used by the application. This is related to https://issues.jboss.org/browse/CDI-411
