### PR TITLE
CDITCK-416 Extend tests for BeanAttributes#getTypes() with generic scenario

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/BeanDefinitionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/BeanDefinitionTest.java
@@ -28,6 +28,8 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.util.Set;
 
 import javax.enterprise.context.RequestScoped;
@@ -95,6 +97,43 @@ public class BeanDefinitionTest extends AbstractTest {
         assertTrue(bean.getTypes().contains(DeadlyAnimal.class));
     }
 
+    @SuppressWarnings("unchecked")
+    @Test
+    @SpecAssertions({ @SpecAssertion(section = MANAGED_BEAN_TYPES, id = "a"), @SpecAssertion(section = BEAN_TYPES, id = "a"),
+            @SpecAssertion(section = BEAN_TYPES, id = "l"), @SpecAssertion(section = BEAN, id = "ba") })
+    public void testGenericBeanTypes() {
+        assert getBeans(MyRawBean.class).size() == 1;
+        Bean<MyGenericBean<?>> bean = (Bean<MyGenericBean<?>>) getCurrentManager().getBeans(MyGenericBean.class).iterator().next();
+        assertEquals(bean.getTypes().size(), 5);
+
+        assertTrue(containsClass(bean.getTypes(), MyGenericBean.class));
+        assertFalse(bean.getTypes().contains(MyGenericBean.class));
+
+        assertTrue(containsClass(bean.getTypes(), MyBean.class));
+        assertFalse(bean.getTypes().contains(MyBean.class));
+
+        assertTrue(bean.getTypes().contains(MyInterface.class));
+
+        assertTrue(containsClass(bean.getTypes(), MySuperInterface.class));
+        assertFalse(bean.getTypes().contains(MySuperInterface.class));
+
+        assertTrue(bean.getTypes().contains(Object.class));
+    }
+
+    @Test
+    @SpecAssertions({ @SpecAssertion(section = MANAGED_BEAN_TYPES, id = "a"), @SpecAssertion(section = BEAN_TYPES, id = "a"),
+            @SpecAssertion(section = BEAN_TYPES, id = "l"), @SpecAssertion(section = BEAN, id = "ba") })
+    public void testRawBeanTypes() {
+        assert getBeans(MyRawBean.class).size() == 1;
+        Bean<MyRawBean> bean = getBeans(MyRawBean.class).iterator().next();
+        assertEquals(bean.getTypes().size(), 5);
+        assertTrue(bean.getTypes().contains(MyRawBean.class));
+        assertTrue(bean.getTypes().contains(MyBean.class));
+        assertTrue(bean.getTypes().contains(MyInterface.class));
+        assertTrue(bean.getTypes().contains(MySuperInterface.class));
+        assertTrue(bean.getTypes().contains(Object.class));
+    }
+
     @Test
     @SpecAssertion(section = TYPECASTING_BETWEEN_BEAN_TYPES, id = "a")
     @SuppressWarnings("unused")
@@ -150,5 +189,21 @@ public class BeanDefinitionTest extends AbstractTest {
         Set<Bean<Horse>> beans = getBeans(Horse.class);
         assertEquals(beans.size(), 1);
         assertEquals(beans.iterator().next().getBeanClass(), Horse.class);
+    }
+
+    private static boolean containsClass(Set<Type> types, Class<?> clazz) {
+        for (Type type : types) {
+            if (type instanceof Class<?>) {
+                if (((Class<?>) type).equals(clazz)) {
+                    return true;
+                }
+            }
+            if (type instanceof ParameterizedType) {
+                if (((ParameterizedType) type).getRawType().equals(clazz)) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/MyBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/MyBean.java
@@ -1,0 +1,20 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.cdi.tck.tests.definition.bean;
+
+class MyBean<T> implements MyInterface {
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/MyGenericBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/MyGenericBean.java
@@ -1,0 +1,20 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.cdi.tck.tests.definition.bean;
+
+class MyGenericBean<T> extends MyBean<T> {
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/MyInterface.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/MyInterface.java
@@ -1,0 +1,20 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.cdi.tck.tests.definition.bean;
+
+interface MyInterface extends MySuperInterface<Number> {
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/MyRawBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/MyRawBean.java
@@ -1,0 +1,21 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.cdi.tck.tests.definition.bean;
+
+@SuppressWarnings("rawtypes")
+class MyRawBean extends MyBean {
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/MySuperInterface.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/MySuperInterface.java
@@ -1,0 +1,20 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.cdi.tck.tests.definition.bean;
+
+interface MySuperInterface<T> {
+}


### PR DESCRIPTION
Test both
- bean with generic class
- bean extending raw type of generic superclass
