### PR TITLE
Bump version to a 2.0.7-SNAPSHOT.

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.cdi.tck</groupId>
 		<artifactId>cdi-tck-parent</artifactId>
-    <version>2.0.6</version>
+    <version>2.0.7-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>cdi-tck-api</artifactId>

--- a/doc/reference/pom.xml
+++ b/doc/reference/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.jboss.cdi.tck</groupId>
         <artifactId>cdi-tck-parent</artifactId>
-        <version>2.0.6</version>
+        <version>2.0.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -191,6 +191,6 @@
         <connection>scm:git:git://github.com/cdi-spec/cditck.git</connection>
         <developerConnection>scm:git:git@github.com:cdi-spec/cdi-tck.git</developerConnection>
         <url>https://github.com/cdi-spec/cdi-tck/</url>
-      <tag>2.0.5.SP1</tag>
+      <tag>HEAD</tag>
   </scm>
 </project>

--- a/ext-lib/pom.xml
+++ b/ext-lib/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cdi-tck-parent</artifactId>
         <groupId>org.jboss.cdi.tck</groupId>
-        <version>2.0.6</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
     <artifactId>cdi-tck-ext-lib</artifactId>
     <name>CDI TCK Installed Library - test bean archive</name>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cdi-tck-parent</artifactId>
         <groupId>org.jboss.cdi.tck</groupId>
-        <version>2.0.6</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>cdi-tck-impl</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.jboss.cdi.tck</groupId>
     <artifactId>cdi-tck-parent</artifactId>
     <packaging>pom</packaging>
-    <version>2.0.6</version>
+    <version>2.0.7-SNAPSHOT</version>
     <name>CDI TCK</name>
 
     <parent>
@@ -348,7 +348,7 @@
         <connection>scm:git:git://github.com/cdi-spec/cdi-tck.git</connection>
         <developerConnection>scm:git:git@github.com:cdi-spec/cdi-tck.git</developerConnection>
         <url>https://github.com/cdi-spec/cdi-tck</url>
-        <tag>2.0.6</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <profiles>


### PR DESCRIPTION
Maven release plugin requires to have SNAPSHOT version to work, so let's give it one.