### PR TITLE
TCK dist build modules require to have relative path to parent specif…

### DIFF
--- a/dist-build/libs/pom.xml
+++ b/dist-build/libs/pom.xml
@@ -4,6 +4,7 @@
         <groupId>jakarta.enterprise</groupId>
         <artifactId>cdi-tck-parent</artifactId>
         <version>2.0.7-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <groupId>jakarta.enterprise</groupId>

--- a/dist-build/pom.xml
+++ b/dist-build/pom.xml
@@ -5,6 +5,7 @@
       <groupId>jakarta.enterprise</groupId>
       <artifactId>cdi-tck-parent</artifactId>
       <version>2.0.7-SNAPSHOT</version>
+      <relativePath>../pom.xml</relativePath>
    </parent>
 
    <groupId>jakarta.enterprise</groupId>

--- a/dist-build/porting-package/pom.xml
+++ b/dist-build/porting-package/pom.xml
@@ -5,6 +5,7 @@
         <groupId>jakarta.enterprise</groupId>
         <artifactId>cdi-tck-parent</artifactId>
         <version>2.0.7-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <groupId>jakarta.enterprise</groupId>


### PR DESCRIPTION
…ied.