### PR TITLE
Replace javax.jws with jakarta.jws

### DIFF
--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -119,6 +119,11 @@
         </dependency>
 
         <dependency>
+            <groupId>jakarta.jws</groupId>
+            <artifactId>jakarta.jws-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>commons-httpclient</groupId>
             <artifactId>commons-httpclient</artifactId>
         </dependency>

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/non/contextual/Translator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/non/contextual/Translator.java
@@ -16,9 +16,9 @@
  */
 package org.jboss.cdi.tck.tests.lookup.injection.non.contextual;
 
-import javax.jws.WebMethod;
-import javax.jws.WebParam;
-import javax.jws.WebService;
+import jakarta.jws.WebMethod;
+import jakarta.jws.WebParam;
+import jakarta.jws.WebService;
 
 @WebService(targetNamespace = "http://contextual.non.injection.lookup.tests.tck.cdi.jboss.org/")
 public interface Translator {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/non/contextual/TranslatorEndpoint.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/non/contextual/TranslatorEndpoint.java
@@ -16,7 +16,7 @@
  */
 package org.jboss.cdi.tck.tests.lookup.injection.non.contextual;
 
-import javax.jws.WebService;
+import jakarta.jws.WebService;
 
 @WebService(endpointInterface = "org.jboss.cdi.tck.tests.lookup.injection.non.contextual.Translator", serviceName = "Translator")
 public class TranslatorEndpoint implements Translator {

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,7 @@
         <el.api.version>4.0.0</el.api.version>
         <jsf.api.version>3.0.0-RC1</jsf.api.version>
         <jaxrs.api.version>3.0.0-M1</jaxrs.api.version>
+        <jws.api.version>3.0.0-RC2</jws.api.version>
         <!-- Test tools/dependencies -->
         <jboss.test.audit.version>1.1.4.Final</jboss.test.audit.version>
         <testng.version>6.14.3</testng.version>
@@ -223,6 +224,12 @@
                 <groupId>jakarta.ws.rs</groupId>
                 <artifactId>jakarta.ws.rs-api</artifactId>
                 <version>${jaxrs.api.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>jakarta.jws</groupId>
+                <artifactId>jakarta.jws-api</artifactId>
+                <version>${jws.api.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
A handful of tests are still using the javax.jws api