### PR TITLE
Update TestNG to 7.3; perform changes needed to execute tests with th…

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/impl/testng/ProgressLoggingTestListener.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/impl/testng/ProgressLoggingTestListener.java
@@ -22,7 +22,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.testng.IInvokedMethod;
-import org.testng.IInvokedMethodListener2;
+import org.testng.IInvokedMethodListener;
 import org.testng.ITestContext;
 import org.testng.ITestResult;
 
@@ -31,7 +31,7 @@ import org.testng.ITestResult;
  *
  * @author Martin Kouba
  */
-public class ProgressLoggingTestListener implements IInvokedMethodListener2 {
+public class ProgressLoggingTestListener implements IInvokedMethodListener {
 
     private final Logger logger = Logger.getLogger(ProgressLoggingTestListener.class.getName());
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/application/ejb/ApplicationContextSharedTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/application/ejb/ApplicationContextSharedTest.java
@@ -117,7 +117,7 @@ public class ApplicationContextSharedTest extends AbstractTest {
         Future<Double> result = bar.compute();
         Double id = result.get();
         assertNotEquals(id, -1.00);
-        assertEquals(id, simpleApplicationBean.getId());
+        assertEquals(id, Double.valueOf(simpleApplicationBean.getId()));
     }
 
     @OperateOnDeployment("TEST")

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/ResolutionByTypeTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/ResolutionByTypeTest.java
@@ -129,8 +129,8 @@ public class ResolutionByTypeTest extends AbstractTest {
         double max = getContextualReference(double.class, new AnnotationLiteral<Max>() {
         });
 
-        assertEquals(min, NumberProducer.min);
-        assertEquals(max, NumberProducer.max);
+        assertEquals(min, Double.valueOf(NumberProducer.min));
+        assertEquals(Double.valueOf(max), NumberProducer.max);
     }
 
     @Test

--- a/impl/src/main/resources/tck-tests-previous.xml
+++ b/impl/src/main/resources/tck-tests-previous.xml
@@ -1,4 +1,4 @@
-<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >
 <suite name="CDI TCK" verbose="0" configfailurepolicy="continue" useDefaultListeners="false">
 
     <!-- !!!!!! WARNING + README !!!!!!

--- a/impl/src/main/resources/tck-tests.xml
+++ b/impl/src/main/resources/tck-tests.xml
@@ -1,4 +1,4 @@
-<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >
 <suite name="CDI TCK" verbose="0" configfailurepolicy="continue" useDefaultListeners="false">
 
     <listeners>

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <jaxrs.api.version>3.0.0</jaxrs.api.version>
         <!-- Test tools/dependencies -->
         <jboss.test.audit.version>1.1.4.Final</jboss.test.audit.version>
-        <testng.version>6.14.3</testng.version>
+        <testng.version>7.3.0</testng.version>
         <arquillian.version>1.7.0.Alpha2</arquillian.version>
         <arquillian.container.se.api.version>1.0.1.Final</arquillian.container.se.api.version>
         <apache.httpclient.version>3.1</apache.httpclient.version>


### PR DESCRIPTION
…is version.

Fixes #220 

Note that doing this means any implementation will need to use TestNG 7.x to execute the testsuite. However, this version comes with the TCK itself, so it shouldn't be an issue.