### PR TITLE
Update test-audit utils to 2.0.0.Final which fixes JDK 11 build.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,8 +113,8 @@
         <jsf.api.version>3.0.0-RC1</jsf.api.version>
         <jaxrs.api.version>3.0.0</jaxrs.api.version>
         <!-- Test tools/dependencies -->
-        <jboss.test.audit.version>1.1.4.Final</jboss.test.audit.version>
         <testng.version>7.3.0</testng.version>
+        <jboss.test.audit.version>2.0.0.Final</jboss.test.audit.version>
         <arquillian.version>1.7.0.Alpha2</arquillian.version>
         <arquillian.container.se.api.version>1.0.1.Final</arquillian.container.se.api.version>
         <apache.httpclient.version>3.1</apache.httpclient.version>


### PR DESCRIPTION
Fixes #219 