### PR TITLE
Introduce BeansXML API for beans.xml file creation.

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/aroundConstruct/ConstructorInterceptionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/aroundConstruct/ConstructorInterceptionTest.java
@@ -23,14 +23,12 @@ import static org.jboss.cdi.tck.interceptors.InterceptorsSections.INVOCATIONCONT
 import static org.jboss.cdi.tck.util.ActionSequence.assertSequenceDataEquals;
 
 import jakarta.enterprise.inject.Instance;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.cdi.tck.util.ActionSequence;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -50,12 +48,8 @@ public class ConstructorInterceptionTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder()
                 .withTestClassPackage(ConstructorInterceptionTest.class)
-                .withBeansXml(
-                        Descriptors
-                                .create(BeansDescriptor.class)
-                                .getOrCreateInterceptors()
-                                .clazz(AlphaInterceptor1.class.getName(), AlphaInterceptor2.class.getName(),
-                                        BravoInterceptor.class.getName()).up()).build();
+                .withBeansXml(new BeansXml().interceptors(AlphaInterceptor1.class, AlphaInterceptor2.class, BravoInterceptor.class))
+                .build();
     }
 
     @Test(dataProvider = ARQUILLIAN_DATA_PROVIDER)

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/aroundConstruct/ejb/SessionBeanConstructorInterceptionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/aroundConstruct/ejb/SessionBeanConstructorInterceptionTest.java
@@ -22,14 +22,12 @@ import static org.jboss.cdi.tck.interceptors.InterceptorsSections.INT_BINDING_TY
 import static org.jboss.cdi.tck.util.ActionSequence.assertSequenceDataEquals;
 
 import jakarta.enterprise.inject.Instance;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.cdi.tck.util.ActionSequence;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -49,12 +47,8 @@ public class SessionBeanConstructorInterceptionTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder()
                 .withTestClassPackage(SessionBeanConstructorInterceptionTest.class)
-                .withBeansXml(
-                        Descriptors
-                                .create(BeansDescriptor.class)
-                                .getOrCreateInterceptors()
-                                .clazz(AlphaInterceptor1.class.getName(), AlphaInterceptor2.class.getName(),
-                                        BravoInterceptor.class.getName()).up()).build();
+                .withBeansXml(new BeansXml().interceptors(AlphaInterceptor1.class, AlphaInterceptor2.class, BravoInterceptor.class))
+                .build();
     }
 
     @Test(groups = INTEGRATION, dataProvider = ARQUILLIAN_DATA_PROVIDER)

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/broken/InvalidStereotypeInterceptorBindingAnnotationsTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/broken/InvalidStereotypeInterceptorBindingAnnotationsTest.java
@@ -19,14 +19,12 @@ package org.jboss.cdi.tck.interceptors.tests.bindings.broken;
 import static org.jboss.cdi.tck.interceptors.InterceptorsSections.INT_BINDING_TYPES_WITH_MEMBERS;
 
 import jakarta.enterprise.inject.spi.DefinitionException;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -47,12 +45,8 @@ public class InvalidStereotypeInterceptorBindingAnnotationsTest extends Abstract
                 .withClasses(Bar.class, FooBinding.class, BarBinding.class, BazBinding.class, FooInterceptor.class,
                         BarInterceptor.class, YesBazInterceptor.class, NoBazInterceptor.class, FooStereotype.class,
                         BarStereotype.class)
-                .withBeansXml(
-                        Descriptors
-                                .create(BeansDescriptor.class)
-                                .getOrCreateInterceptors()
-                                .clazz(FooInterceptor.class.getName(), BarInterceptor.class.getName(),
-                                        YesBazInterceptor.class.getName(), NoBazInterceptor.class.getName()).up()).build();
+                .withBeansXml(new BeansXml().interceptors(FooInterceptor.class, BarInterceptor.class, YesBazInterceptor.class, NoBazInterceptor.class))
+                .build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/broken/InvalidTransitiveInterceptorBindingAnnotationsTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/broken/InvalidTransitiveInterceptorBindingAnnotationsTest.java
@@ -19,14 +19,12 @@ package org.jboss.cdi.tck.interceptors.tests.bindings.broken;
 import static org.jboss.cdi.tck.interceptors.InterceptorsSections.INT_BINDING_TYPES_WITH_MEMBERS;
 
 import jakarta.enterprise.inject.spi.DefinitionException;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -44,12 +42,9 @@ public class InvalidTransitiveInterceptorBindingAnnotationsTest extends Abstract
                 .withTestClass(InvalidTransitiveInterceptorBindingAnnotationsTest.class)
                 .withClasses(Foo.class, FooBinding.class, BarBinding.class, BazBinding.class, FooInterceptor.class,
                         BarInterceptor.class, YesBazInterceptor.class, NoBazInterceptor.class)
-                .withBeansXml(
-                        Descriptors
-                                .create(BeansDescriptor.class)
-                                .getOrCreateInterceptors()
-                                .clazz(FooInterceptor.class.getName(), BarInterceptor.class.getName(),
-                                        YesBazInterceptor.class.getName(), NoBazInterceptor.class.getName()).up()).build();
+                .withBeansXml(new BeansXml().interceptors(FooInterceptor.class, BarInterceptor.class,
+                        YesBazInterceptor.class, NoBazInterceptor.class))
+                .build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/members/InterceptorBindingTypeWithMemberTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/members/InterceptorBindingTypeWithMemberTest.java
@@ -21,21 +21,19 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
-import java.util.List;
-
 import jakarta.enterprise.inject.spi.InterceptionType;
 import jakarta.enterprise.inject.spi.Interceptor;
 import jakarta.enterprise.util.AnnotationLiteral;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
+
+import java.util.List;
 
 /**
  * Tests for interceptor bindings types with members.
@@ -55,12 +53,8 @@ public class InterceptorBindingTypeWithMemberTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder()
                 .withTestClassPackage(InterceptorBindingTypeWithMemberTest.class)
-                .withBeansXml(
-                        Descriptors
-                                .create(BeansDescriptor.class)
-                                .getOrCreateInterceptors()
-                                .clazz(IncreasingInterceptor.class.getName(), DecreasingInterceptor.class.getName(),
-                                        VehicleCountInterceptor.class.getName(), PlantInterceptor.class.getName()).up())
+                .withBeansXml(new BeansXml()
+                        .interceptors(IncreasingInterceptor.class, DecreasingInterceptor.class, VehicleCountInterceptor.class, PlantInterceptor.class))
                 .build();
     }
 

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/multiple/MultipleInterceptorBindingsTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/multiple/MultipleInterceptorBindingsTest.java
@@ -25,8 +25,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -38,9 +37,8 @@ public class MultipleInterceptorBindingsTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder()
                 .withTestClassPackage(MultipleInterceptorBindingsTest.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors()
-                                .clazz(MissileInterceptor.class.getName(), LockInterceptor.class.getName()).up()).build();
+                .withBeansXml(new BeansXml().interceptors(MissileInterceptor.class, LockInterceptor.class))
+                .build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/overriding/InterceptorBindingOverridingTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/overriding/InterceptorBindingOverridingTest.java
@@ -21,13 +21,11 @@ import static org.jboss.cdi.tck.interceptors.InterceptorsSections.INT_BINDING_TY
 import static org.testng.Assert.assertEquals;
 
 import jakarta.inject.Inject;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -49,12 +47,8 @@ public class InterceptorBindingOverridingTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder()
                 .withTestClassPackage(InterceptorBindingOverridingTest.class)
-                .withBeansXml(
-                        Descriptors
-                                .create(BeansDescriptor.class)
-                                .getOrCreateInterceptors()
-                                .clazz(NegatingInterceptor.class.getName(), FastAgingInterceptor.class.getName(),
-                                        SlowAgingInterceptor.class.getName()).up()).build();
+                .withBeansXml(new BeansXml().interceptors(NegatingInterceptor.class, FastAgingInterceptor.class, SlowAgingInterceptor.class))
+                .build();
     }
 
     @Inject

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/InterceptorBindingResolutionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/InterceptorBindingResolutionTest.java
@@ -38,6 +38,7 @@ import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -54,11 +55,9 @@ public class InterceptorBindingResolutionTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder()
                 .withTestClassPackage(InterceptorBindingResolutionTest.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors()
-                                .clazz(ComplicatedInterceptor.class.getName(), ComplicatedLifecycleInterceptor.class.getName(),
-                                        ComplicatedAroundConstructInterceptor.class.getName())
-                                .up()).build();
+                .withBeansXml(new BeansXml()
+                        .interceptors(ComplicatedInterceptor.class, ComplicatedLifecycleInterceptor.class, ComplicatedAroundConstructInterceptor.class))
+                .build();
     }
 
     @SuppressWarnings("serial")

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/EnterpriseInterceptorBindingResolutionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/EnterpriseInterceptorBindingResolutionTest.java
@@ -25,24 +25,22 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
-import java.util.concurrent.TimeUnit;
-
 import jakarta.enterprise.context.spi.CreationalContext;
 import jakarta.enterprise.inject.spi.Bean;
 import jakarta.enterprise.inject.spi.InterceptionType;
 import jakarta.enterprise.util.AnnotationLiteral;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.cdi.tck.util.Timer;
 import org.jboss.cdi.tck.util.Timer.StopCondition;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
+
+import java.util.concurrent.TimeUnit;
 
 /**
  * Interceptor resolution test.
@@ -57,10 +55,8 @@ public class EnterpriseInterceptorBindingResolutionTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder()
                 .withTestClassPackage(EnterpriseInterceptorBindingResolutionTest.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors()
-                                .clazz(ComplicatedInterceptor.class.getName(), ComplicatedLifecycleInterceptor.class.getName())
-                                .up()).build();
+                .withBeansXml(new BeansXml().interceptors(ComplicatedInterceptor.class, ComplicatedLifecycleInterceptor.class))
+                .build();
     }
 
     @SuppressWarnings("serial")

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/bindings/AroundConstructTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/bindings/AroundConstructTest.java
@@ -26,14 +26,12 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.fail;
 
 import jakarta.enterprise.inject.Instance;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.cdi.tck.util.ActionSequence;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -54,12 +52,9 @@ public class AroundConstructTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder()
                 .withTestClassPackage(AroundConstructTest.class)
-                .withBeansXml(
-                        Descriptors
-                                .create(BeansDescriptor.class)
-                                .getOrCreateInterceptors()
-                                .clazz(AlphaInterceptor.class.getName(), BravoInterceptor.class.getName(),
-                                        CharlieInterceptor1.class.getName(), CharlieInterceptor2.class.getName()).up()).build();
+                .withBeansXml(new BeansXml().interceptors(AlphaInterceptor.class, BravoInterceptor.class,
+                        CharlieInterceptor1.class, CharlieInterceptor2.class))
+                .build();
     }
 
     @Test(dataProvider = ARQUILLIAN_DATA_PROVIDER)

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/bindings/LifecycleInterceptorDefinitionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/bindings/LifecycleInterceptorDefinitionTest.java
@@ -30,6 +30,7 @@ import org.jboss.cdi.tck.util.ActionSequence;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -41,9 +42,7 @@ public class LifecycleInterceptorDefinitionTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder()
                 .withTestClassPackage(LifecycleInterceptorDefinitionTest.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors()
-                                .clazz(AirborneInterceptor.class.getName(), DestructionInterceptor.class.getName()).up())
+                .withBeansXml(new BeansXml().interceptors(AirborneInterceptor.class, DestructionInterceptor.class))
                 .build();
     }
 

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/bindings/ejb/SessionBeanLifecycleInterceptorDefinitionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/bindings/ejb/SessionBeanLifecycleInterceptorDefinitionTest.java
@@ -23,14 +23,12 @@ import static org.testng.Assert.assertEquals;
 
 import jakarta.enterprise.context.spi.CreationalContext;
 import jakarta.enterprise.inject.spi.Bean;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.cdi.tck.util.ActionSequence;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -42,9 +40,7 @@ public class SessionBeanLifecycleInterceptorDefinitionTest extends AbstractTest 
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder()
                 .withTestClassPackage(SessionBeanLifecycleInterceptorDefinitionTest.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors()
-                                .clazz(AirborneInterceptor.class.getName(), DestructionInterceptor.class.getName()).up())
+                .withBeansXml(new BeansXml().interceptors(AirborneInterceptor.class, DestructionInterceptor.class))
                 .build();
     }
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/AlternativeAvailabilityTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/AlternativeAvailabilityTest.java
@@ -42,6 +42,7 @@ import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -54,9 +55,8 @@ public class AlternativeAvailabilityTest extends AbstractTest {
         return new WebArchiveBuilder()
                 .withTestClassPackage(AlternativeAvailabilityTest.class)
                 .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateAlternatives()
-                                .clazz(Chicken.class.getName(), EnabledSheepProducer.class.getName(), SnakeProducer.class.getName())
-                                .stereotype(EnabledAlternativeStereotype.class.getName()).up()).build();
+                        new BeansXml().alternatives(Chicken.class, EnabledSheepProducer.class, SnakeProducer.class)
+                            .stereotype(EnabledAlternativeStereotype.class)).build();
     }
 
     @SuppressWarnings("serial")

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/broken/incorrect/name/NoClassWithSpecifiedNameTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/broken/incorrect/name/NoClassWithSpecifiedNameTest.java
@@ -20,14 +20,11 @@ import static org.jboss.cdi.tck.cdi.Sections.DECLARING_SELECTED_ALTERNATIVES_BEA
 import static org.jboss.cdi.tck.cdi.Sections.EXCEPTIONS;
 
 import jakarta.enterprise.inject.spi.DeploymentException;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -40,12 +37,8 @@ public class NoClassWithSpecifiedNameTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder()
                 .withTestClassPackage(NoClassWithSpecifiedNameTest.class)
-                .withBeansXml(
-                        Descriptors
-                                .create(BeansDescriptor.class)
-                                .getOrCreateAlternatives()
-                                .clazz("org.jboss.jsr299.org.jboss.cdi.tck.tests.alternative.broken.incorrect.name.NonExistingClass")
-                                .up()).build();
+                .withBeansXml("beans.xml")
+                .build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/broken/incorrect/name/stereotype/NoAnnotationWithSpecifiedNameTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/broken/incorrect/name/stereotype/NoAnnotationWithSpecifiedNameTest.java
@@ -19,14 +19,11 @@ package org.jboss.cdi.tck.tests.alternative.broken.incorrect.name.stereotype;
 import static org.jboss.cdi.tck.cdi.Sections.DECLARING_SELECTED_ALTERNATIVES_BEAN_ARCHIVE;
 
 import jakarta.enterprise.inject.spi.DeploymentException;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -39,9 +36,7 @@ public class NoAnnotationWithSpecifiedNameTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder()
                 .withTestClassPackage(NoAnnotationWithSpecifiedNameTest.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateAlternatives()
-                                .stereotype("org.jboss.cdi.tck.tests.policy.broken.incorrect.name.stereotype.Mock").up())
+                .withBeansXml("beans.xml")
                 .build();
     }
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/broken/not/alternative/ClassIsNotAlternativeTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/broken/not/alternative/ClassIsNotAlternativeTest.java
@@ -19,14 +19,12 @@ package org.jboss.cdi.tck.tests.alternative.broken.not.alternative;
 import static org.jboss.cdi.tck.cdi.Sections.DECLARING_SELECTED_ALTERNATIVES_BEAN_ARCHIVE;
 
 import jakarta.enterprise.inject.spi.DeploymentException;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -38,7 +36,7 @@ public class ClassIsNotAlternativeTest extends AbstractTest {
     @Deployment
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder().withTestClassPackage(ClassIsNotAlternativeTest.class)
-                .withBeansXml(Descriptors.create(BeansDescriptor.class).getOrCreateAlternatives().clazz(Cat.class.getName()).up())
+                .withBeansXml(new BeansXml().alternatives(Cat.class))
                 .build();
     }
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/broken/not/alternative/stereotype/ClassIsNotAlternativeTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/broken/not/alternative/stereotype/ClassIsNotAlternativeTest.java
@@ -27,6 +27,7 @@ import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -38,7 +39,7 @@ public class ClassIsNotAlternativeTest extends AbstractTest {
     @Deployment
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder().withTestClassPackage(ClassIsNotAlternativeTest.class)
-                .withBeansXml(Descriptors.create(BeansDescriptor.class).getOrCreateAlternatives().clazz(Mock.class.getName()).up())
+                .withBeansXml(new BeansXml().alternatives(Mock.class))
                 .build();
     }
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/broken/same/type/twice/SameTypeListedTwiceTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/broken/same/type/twice/SameTypeListedTwiceTest.java
@@ -27,6 +27,7 @@ import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -39,9 +40,8 @@ public class SameTypeListedTwiceTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder()
                 .withTestClassPackage(SameTypeListedTwiceTest.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateAlternatives()
-                                .clazz(Dog.class.getName(), Cat.class.getName(), Cat.class.getName()).up()).build();
+                .withBeansXml(new BeansXml().alternatives(Dog.class, Cat.class, Cat.class))
+                .build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/enterprise/resource/ResourceAlternativeAvailabilityTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/enterprise/resource/ResourceAlternativeAvailabilityTest.java
@@ -22,22 +22,20 @@ import static org.jboss.cdi.tck.cdi.Sections.DECLARING_SELECTED_ALTERNATIVES_BEA
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
-import java.util.Set;
-
 import jakarta.enterprise.inject.spi.Bean;
 import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
+
+import java.util.Set;
 
 /**
  * @author Martin Kouba
@@ -50,9 +48,8 @@ public class ResourceAlternativeAvailabilityTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder()
                 .withTestClassPackage(ResourceAlternativeAvailabilityTest.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateAlternatives()
-                                .clazz(EnabledResourceProducer.class.getName()).up()).withDefaultPersistenceXml().build();
+                .withBeansXml(new BeansXml().alternatives(EnabledResourceProducer.class))
+                .withDefaultPersistenceXml().build();
     }
 
     @Inject

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/QualifierInheritedTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/QualifierInheritedTest.java
@@ -23,20 +23,18 @@ import static org.jboss.cdi.tck.cdi.Sections.TYPE_LEVEL_INHERITANCE;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
-import java.lang.annotation.Inherited;
-
 import jakarta.enterprise.inject.spi.Bean;
 import jakarta.inject.Inject;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
+
+import java.lang.annotation.Inherited;
 
 /**
  *
@@ -49,7 +47,7 @@ public class QualifierInheritedTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder().withTestClass(QualifierInheritedTest.class)
                 .withClasses(Tree.class, Larch.class, Forest.class, True.class, TrueLiteral.class)
-                .withBeansXml(Descriptors.create(BeansDescriptor.class).getOrCreateAlternatives().clazz(Larch.class.getName()).up())
+                .withBeansXml(new BeansXml().alternatives(Larch.class))
                 .build();
     }
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/QualifierNotDeclaredTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/QualifierNotDeclaredTest.java
@@ -24,13 +24,11 @@ import static org.testng.Assert.assertNotNull;
 
 import jakarta.enterprise.inject.spi.Bean;
 import jakarta.inject.Inject;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -46,7 +44,7 @@ public class QualifierNotDeclaredTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder().withTestClass(QualifierNotDeclaredTest.class)
                 .withClasses(Foo.class, Bar.class, Baz.class, Qux.class, True.class, TrueLiteral.class)
-                .withBeansXml(Descriptors.create(BeansDescriptor.class).getOrCreateAlternatives().clazz(Bar.class.getName()).up())
+                .withBeansXml(new BeansXml().alternatives(Bar.class))
                 .build();
     }
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/QualifierNotInheritedTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/QualifierNotInheritedTest.java
@@ -23,20 +23,18 @@ import static org.jboss.cdi.tck.cdi.Sections.TYPE_LEVEL_INHERITANCE;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
-import java.lang.annotation.Inherited;
-
 import jakarta.enterprise.inject.spi.Bean;
 import jakarta.inject.Inject;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
+
+import java.lang.annotation.Inherited;
 
 /**
  *
@@ -49,7 +47,7 @@ public class QualifierNotInheritedTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder().withTestClass(QualifierNotInheritedTest.class)
                 .withClasses(Monster.class, Troll.class, Dungeon.class, False.class, FalseLiteral.class)
-                .withBeansXml(Descriptors.create(BeansDescriptor.class).getOrCreateAlternatives().clazz(Troll.class.getName()).up())
+                .withBeansXml(new BeansXml().alternatives(Troll.class))
                 .build();
     }
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/stereotype/SelectedBeanWithUnselectedStereotypeTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/stereotype/SelectedBeanWithUnselectedStereotypeTest.java
@@ -20,20 +20,18 @@ package org.jboss.cdi.tck.tests.alternative.selection.stereotype;
 import static org.jboss.cdi.tck.cdi.Sections.DECLARING_SELECTED_ALTERNATIVES_BEAN_ARCHIVE;
 import static org.testng.Assert.assertEquals;
 
-import java.util.Set;
-
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.enterprise.inject.spi.Bean;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
+
+import java.util.Set;
 
 /**
  * @author Martin Kouba
@@ -44,7 +42,7 @@ public class SelectedBeanWithUnselectedStereotypeTest extends AbstractTest {
     @Deployment
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder().withTestClassPackage(SelectedBeanWithUnselectedStereotypeTest.class)
-                .withBeansXml(Descriptors.create(BeansDescriptor.class).getOrCreateAlternatives().clazz(Bar.class.getName()).up())
+                .withBeansXml(new BeansXml().alternatives(Bar.class))
                 .build();
     }
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/veto/VetoedAlternativeTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/veto/VetoedAlternativeTest.java
@@ -19,13 +19,11 @@ package org.jboss.cdi.tck.tests.alternative.veto;
 import static org.jboss.cdi.tck.cdi.Sections.DECLARING_SELECTED_ALTERNATIVES_BEAN_ARCHIVE;
 
 import jakarta.enterprise.context.RequestScoped;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.Assert;
@@ -43,9 +41,8 @@ public class VetoedAlternativeTest extends AbstractTest {
                 .withTestClassPackage(VetoedAlternativeTest.class)
                 .withExtension(VetoingExtension.class)
                 .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateAlternatives()
-                                .clazz(MockPaymentProcessorImpl.class.getName())
-                                .stereotype(AlternativeConsumerStereotype.class.getName()).up()).build();
+                        new BeansXml().alternatives(MockPaymentProcessorImpl.class).stereotype(AlternativeConsumerStereotype.class))
+                .build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/decorator/ManagedBeanWithNonPassivatingDecoratorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/decorator/ManagedBeanWithNonPassivatingDecoratorTest.java
@@ -19,14 +19,12 @@ package org.jboss.cdi.tck.tests.context.passivating.broken.decorator;
 import static org.jboss.cdi.tck.cdi.Sections.PASSIVATION_VALIDATION;
 
 import jakarta.enterprise.inject.spi.DeploymentException;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -37,12 +35,9 @@ public class ManagedBeanWithNonPassivatingDecoratorTest extends AbstractTest {
     @ShouldThrowException(DeploymentException.class)
     @Deployment
     public static WebArchive createTestArchive() {
-        // Originally EAR but no enterprise feature used
         return new WebArchiveBuilder()
                 .withTestClassPackage(ManagedBeanWithNonPassivatingDecoratorTest.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateDecorators()
-                                .clazz(MaarianhaminaDecorator.class.getName()).up()).build();
+                .withBeansXml(new BeansXml().decorators(MaarianhaminaDecorator.class)).build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/decorator/enterprise/EnterpriseBeanWithNonPassivatingDecoratorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/decorator/enterprise/EnterpriseBeanWithNonPassivatingDecoratorTest.java
@@ -20,14 +20,12 @@ import static org.jboss.cdi.tck.TestGroups.INTEGRATION;
 import static org.jboss.cdi.tck.cdi.Sections.PASSIVATION_VALIDATION_EE;
 
 import jakarta.enterprise.inject.spi.DeploymentException;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -40,9 +38,7 @@ public class EnterpriseBeanWithNonPassivatingDecoratorTest extends AbstractTest 
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder()
                 .withTestClassPackage(EnterpriseBeanWithNonPassivatingDecoratorTest.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateDecorators()
-                                .clazz(MaarianhaminaDecorator.class.getName()).up()).build();
+                .withBeansXml(new BeansXml().decorators(MaarianhaminaDecorator.class)).build();
     }
 
     @Test(groups =  INTEGRATION)

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/decorator/enterprise/field/EnterpriseBeanWithNonPassivatingInjectedFieldInDecoratorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/decorator/enterprise/field/EnterpriseBeanWithNonPassivatingInjectedFieldInDecoratorTest.java
@@ -20,14 +20,12 @@ import static org.jboss.cdi.tck.TestGroups.INTEGRATION;
 import static org.jboss.cdi.tck.cdi.Sections.PASSIVATION_VALIDATION_EE;
 
 import jakarta.enterprise.inject.spi.DeploymentException;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -40,9 +38,7 @@ public class EnterpriseBeanWithNonPassivatingInjectedFieldInDecoratorTest extend
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder()
                 .withTestClassPackage(EnterpriseBeanWithNonPassivatingInjectedFieldInDecoratorTest.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateDecorators().clazz(BrokenDecorator.class.getName())
-                                .up()).build();
+                .withBeansXml(new BeansXml().decorators(BrokenDecorator.class)).build();
     }
 
     @Test(groups =  INTEGRATION)

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/decorator/field/DecoratorWithNonPassivatingInjectedFieldTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/decorator/field/DecoratorWithNonPassivatingInjectedFieldTest.java
@@ -27,6 +27,7 @@ import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -39,9 +40,7 @@ public class DecoratorWithNonPassivatingInjectedFieldTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder()
                 .withTestClassPackage(DecoratorWithNonPassivatingInjectedFieldTest.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateDecorators().clazz(CityDecorator.class.getName()).up())
-                .build();
+                .withBeansXml(new BeansXml().decorators(CityDecorator.class)).build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/interceptor/enterprise/EnterpriseBeanWithNonPassivatingInterceptorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/interceptor/enterprise/EnterpriseBeanWithNonPassivatingInterceptorTest.java
@@ -28,6 +28,7 @@ import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -40,9 +41,7 @@ public class EnterpriseBeanWithNonPassivatingInterceptorTest extends AbstractTes
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder()
                 .withTestClassPackage(EnterpriseBeanWithNonPassivatingInterceptorTest.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors()
-                                .clazz(DigitalInterceptor.class.getName()).up()).build();
+                .withBeansXml(new BeansXml().interceptors(DigitalInterceptor.class)).build();
     }
 
     @Test(groups =  INTEGRATION)

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/interceptor/field/PassivationCapableBeanWithNonPassivatingInterceptorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/interceptor/field/PassivationCapableBeanWithNonPassivatingInterceptorTest.java
@@ -19,14 +19,12 @@ package org.jboss.cdi.tck.tests.context.passivating.broken.interceptor.field;
 import static org.jboss.cdi.tck.cdi.Sections.PASSIVATION_VALIDATION;
 
 import jakarta.enterprise.inject.spi.DeploymentException;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -39,9 +37,7 @@ public class PassivationCapableBeanWithNonPassivatingInterceptorTest extends Abs
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder()
                 .withTestClassPackage(PassivationCapableBeanWithNonPassivatingInterceptorTest.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors().clazz(BrokenInterceptor.class.getName())
-                                .up()).build();
+                .withBeansXml(new BeansXml().interceptors(BrokenInterceptor.class)).build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/NonPassivationCapableSessionBeanTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/NonPassivationCapableSessionBeanTest.java
@@ -25,6 +25,7 @@ import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -47,9 +48,7 @@ public class NonPassivationCapableSessionBeanTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder()
                 .withTestClassPackage(NonPassivationCapableSessionBeanTest.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors()
-                                .clazz(DigitalInterceptor.class.getName()).up()).build();
+                .withBeansXml(new BeansXml().interceptors(DigitalInterceptor.class)).build();
     }
 
     @Test(groups = INTEGRATION)

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/invalid/StatefulSessionBeanTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/invalid/StatefulSessionBeanTest.java
@@ -20,14 +20,12 @@ import static org.jboss.cdi.tck.TestGroups.INTEGRATION;
 import static org.jboss.cdi.tck.cdi.Sections.PASSIVATION_CAPABLE_EE;
 
 import jakarta.enterprise.inject.spi.DeploymentException;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -46,9 +44,7 @@ public class StatefulSessionBeanTest extends AbstractTest {
         return new WebArchiveBuilder()
                 .withTestClass(StatefulSessionBeanTest.class)
                 .withClasses(Digital.class, DigitalInterceptor.class, Telephone.class, TelephoneLine.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors()
-                                .clazz(DigitalInterceptor.class.getName()).up()).build();
+                .withBeansXml(new BeansXml().interceptors(DigitalInterceptor.class)).build();
     }
 
     @Test(groups = INTEGRATION)

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/invalid/StatefulSessionBeanXmlDescriptorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/invalid/StatefulSessionBeanXmlDescriptorTest.java
@@ -28,6 +28,7 @@ import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -46,9 +47,7 @@ public class StatefulSessionBeanXmlDescriptorTest extends AbstractTest {
         return new WebArchiveBuilder()
                 .withTestClass(StatefulSessionBeanXmlDescriptorTest.class)
                 .withClasses(Digital.class, DigitalInterceptor.class, Elephant.class, ElephantLocal.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors()
-                                .clazz(DigitalInterceptor.class.getName()).up())
+                .withBeansXml(new BeansXml().interceptors(DigitalInterceptor.class))
                 .build()
                 .addAsWebInfResource(StatefulSessionBeanXmlDescriptorTest.class.getPackage(), "ejb-jar.xml", "ejb-jar.xml");
     }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/valid/StatefulSessionBeanTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/valid/StatefulSessionBeanTest.java
@@ -23,8 +23,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -43,9 +42,7 @@ public class StatefulSessionBeanTest extends AbstractTest {
         return new WebArchiveBuilder()
                 .withTestClass(StatefulSessionBeanTest.class)
                 .withClasses(Digital.class, DigitalInterceptor.class, Telephone.class, TelephoneLine.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors()
-                                .clazz(DigitalInterceptor.class.getName()).up()).build();
+                .withBeansXml(new BeansXml().interceptors(DigitalInterceptor.class)).build();
     }
 
     @Test(groups = INTEGRATION)

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/valid/StatefulSessionBeanXmlDescriptorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/valid/StatefulSessionBeanXmlDescriptorTest.java
@@ -23,8 +23,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -43,9 +42,7 @@ public class StatefulSessionBeanXmlDescriptorTest extends AbstractTest {
         return new WebArchiveBuilder()
                 .withTestClass(StatefulSessionBeanXmlDescriptorTest.class)
                 .withClasses(Digital.class, DigitalInterceptor.class, Elephant.class, ElephantLocal.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors()
-                                .clazz(DigitalInterceptor.class.getName()).up())
+                .withBeansXml(new BeansXml().interceptors(DigitalInterceptor.class))
                 .build()
                 .addAsWebInfResource(StatefulSessionBeanXmlDescriptorTest.class.getPackage(), "ejb-jar.xml", "ejb-jar.xml");
     }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/passivating/validation/DecoratorWithNonPassivationCapableDependenciesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/passivating/validation/DecoratorWithNonPassivationCapableDependenciesTest.java
@@ -28,6 +28,7 @@ import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -51,9 +52,7 @@ public class DecoratorWithNonPassivationCapableDependenciesTest extends Abstract
         return new WebArchiveBuilder()
                 .withTestClass(DecoratorWithNonPassivationCapableDependenciesTest.class)
                 .withClasses(Engine.class, Ferry.class, Vessel.class, VesselDecorator.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateDecorators().clazz(VesselDecorator.class.getName())
-                                .up()).build();
+                .withBeansXml(new BeansXml().decorators(VesselDecorator.class)).build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/passivating/validation/InterceptorWithNonPassivationCapableDependenciesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/passivating/validation/InterceptorWithNonPassivationCapableDependenciesTest.java
@@ -20,13 +20,11 @@ import static org.jboss.cdi.tck.cdi.Sections.PASSIVATION_VALIDATION;
 import static org.testng.Assert.assertEquals;
 
 import jakarta.enterprise.inject.spi.InterceptionType;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -50,9 +48,7 @@ public class InterceptorWithNonPassivationCapableDependenciesTest extends Abstra
         return new WebArchiveBuilder()
                 .withTestClass(InterceptorWithNonPassivationCapableDependenciesTest.class)
                 .withClasses(Engine.class, EnginePowered.class, EnginePoweredInterceptor.class, Ferry.class, Vessel.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors()
-                                .clazz(EnginePoweredInterceptor.class.getName()).up()).build();
+                .withBeansXml(new BeansXml().interceptors(EnginePoweredInterceptor.class)).build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/beanmanager/BeanManagerDecoratorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/beanmanager/BeanManagerDecoratorTest.java
@@ -24,13 +24,11 @@ import static org.testng.Assert.assertTrue;
 import jakarta.enterprise.inject.Default;
 import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.inject.Inject;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.cdi.tck.tests.decorators.AbstractDecoratorTest;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
@@ -50,8 +48,7 @@ public class BeanManagerDecoratorTest extends AbstractDecoratorTest {
                 .withTestClassPackage(BeanManagerDecoratorTest.class)
                 .withClass(AbstractDecoratorTest.class)
                 .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateDecorators()
-                                .clazz(BeanManagerDecorator.class.getName()).up()).build();
+                        new BeansXml().decorators(BeanManagerDecorator.class)).build();
     }
 
     @Inject

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/conversation/BuiltinConversationDecoratorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/conversation/BuiltinConversationDecoratorTest.java
@@ -22,22 +22,20 @@ import static org.jboss.cdi.tck.cdi.Sections.DECORATOR_RESOLUTION;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 
-import java.lang.reflect.Type;
-import java.util.Collections;
-
 import jakarta.enterprise.context.Conversation;
 import jakarta.inject.Inject;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.cdi.tck.tests.decorators.AbstractDecoratorTest;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
+
+import java.lang.reflect.Type;
+import java.util.Collections;
 
 /**
  * @author Martin Kouba
@@ -52,8 +50,7 @@ public class BuiltinConversationDecoratorTest extends AbstractDecoratorTest {
                 .withTestClassPackage(BuiltinConversationDecoratorTest.class)
                 .withClass(AbstractDecoratorTest.class)
                 .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateDecorators()
-                                .clazz(ConversationDecorator.class.getName()).up()).build();
+                        new BeansXml().decorators(ConversationDecorator.class)).build();
     }
 
     @Inject

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/event/BuiltinEventDecoratorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/event/BuiltinEventDecoratorTest.java
@@ -22,24 +22,22 @@ import static org.jboss.cdi.tck.cdi.Sections.DECORATOR_RESOLUTION;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
-import java.lang.reflect.Type;
-import java.util.Collections;
-
 import jakarta.enterprise.event.Event;
 import jakarta.enterprise.util.TypeLiteral;
 import jakarta.inject.Inject;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.cdi.tck.tests.decorators.AbstractDecoratorTest;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import java.lang.reflect.Type;
+import java.util.Collections;
 
 /**
  * @author Martin Kouba
@@ -54,9 +52,7 @@ public class BuiltinEventDecoratorTest extends AbstractDecoratorTest {
                 .withTestClassPackage(BuiltinEventDecoratorTest.class)
                 .withClass(AbstractDecoratorTest.class)
                 .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateDecorators().clazz(FooEventDecorator.class.getName())
-                        .clazz(StringEventDecorator.class.getName()).clazz(CharSequenceEventDecorator.class.getName())
-                                .up()).build();
+                        new BeansXml().decorators(FooEventDecorator.class, StringEventDecorator.class, CharSequenceEventDecorator.class)).build();
     }
 
     @Inject

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/event/complex/ComplexEventDecoratorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/event/complex/ComplexEventDecoratorTest.java
@@ -30,6 +30,7 @@ import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
@@ -57,8 +58,7 @@ public class ComplexEventDecoratorTest extends AbstractTest {
                 .withTestClassPackage(ComplexEventDecoratorTest.class)
                 .withExtension(OrderedEventDeliveryExtension.class)
                 .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateDecorators()
-                                .clazz(OrderedEventDeliveryDecorator.class.getName()).up()).build();
+                        new BeansXml().decorators(OrderedEventDeliveryDecorator.class)).build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/http/request/BuiltinHttpServletRequestDecoratorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/http/request/BuiltinHttpServletRequestDecoratorTest.java
@@ -23,28 +23,26 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
 
+import jakarta.enterprise.inject.spi.Decorator;
+import jakarta.inject.Inject;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
+import org.jboss.cdi.tck.tests.decorators.AbstractDecoratorTest;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.impl.BeansXml;
+import org.jboss.test.audit.annotations.SpecAssertion;
+import org.jboss.test.audit.annotations.SpecAssertions;
+import org.jboss.test.audit.annotations.SpecVersion;
+import org.testng.annotations.Test;
+
 import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
-
-import jakarta.enterprise.inject.spi.Decorator;
-import jakarta.inject.Inject;
-import jakarta.servlet.ServletRequest;
-import jakarta.servlet.http.HttpServletRequest;
-
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
-import org.jboss.cdi.tck.tests.decorators.AbstractDecoratorTest;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
-import org.jboss.test.audit.annotations.SpecAssertion;
-import org.jboss.test.audit.annotations.SpecAssertions;
-import org.jboss.test.audit.annotations.SpecVersion;
-import org.testng.annotations.Test;
 
 /**
  * @author Martin Kouba
@@ -60,9 +58,7 @@ public class BuiltinHttpServletRequestDecoratorTest extends AbstractDecoratorTes
                 .withTestClassPackage(BuiltinHttpServletRequestDecoratorTest.class)
                 .withClass(AbstractDecoratorTest.class)
                 .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateDecorators()
-                                .clazz(HttpServletRequestDecorator1.class.getName())
-                                .clazz(HttpServletRequestDecorator2.class.getName()).up()).build();
+                        new BeansXml().decorators(HttpServletRequestDecorator1.class, HttpServletRequestDecorator2.class)).build();
     }
 
     @Inject

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/http/servletcontext/BuiltinServletContextDecoratorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/http/servletcontext/BuiltinServletContextDecoratorTest.java
@@ -22,24 +22,22 @@ import static org.jboss.cdi.tck.cdi.Sections.DECORATOR_BEAN_EE;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
-import java.lang.reflect.Type;
-import java.util.Collections;
-import java.util.List;
-
 import jakarta.enterprise.inject.spi.Decorator;
 import jakarta.inject.Inject;
 import jakarta.servlet.ServletContext;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.cdi.tck.tests.decorators.AbstractDecoratorTest;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
+
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * @author Martin Kouba
@@ -55,9 +53,7 @@ public class BuiltinServletContextDecoratorTest extends AbstractDecoratorTest {
                 .withTestClassPackage(BuiltinServletContextDecoratorTest.class)
                 .withClass(AbstractDecoratorTest.class)
                 .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateDecorators()
-                                .clazz(ServletContextDecorator1.class.getName())
-                                .clazz(ServletContextDecorator2.class.getName()).up()).build();
+                        new BeansXml().decorators(ServletContextDecorator1.class, ServletContextDecorator2.class)).build();
     }
 
     @Inject

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/http/session/BuiltinHttpSessionDecoratorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/http/session/BuiltinHttpSessionDecoratorTest.java
@@ -23,24 +23,22 @@ import static org.jboss.cdi.tck.cdi.Sections.DECORATOR_RESOLUTION;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
-import java.lang.reflect.Type;
-import java.util.Collections;
-import java.util.List;
-
 import jakarta.enterprise.inject.spi.Decorator;
 import jakarta.inject.Inject;
 import jakarta.servlet.http.HttpSession;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.cdi.tck.tests.decorators.AbstractDecoratorTest;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
+
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * @author Martin Kouba
@@ -55,9 +53,7 @@ public class BuiltinHttpSessionDecoratorTest extends AbstractDecoratorTest {
                 .withTestClassPackage(BuiltinHttpSessionDecoratorTest.class)
                 .withClass(AbstractDecoratorTest.class)
                 .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateDecorators()
-                                .clazz(HttpSessionDecorator1.class.getName()).clazz(HttpSessionDecorator2.class.getName()).up())
-                .build();
+                        new BeansXml().decorators(HttpSessionDecorator1.class, HttpSessionDecorator2.class)).build();
     }
 
     @Inject

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/injectionpoint/BuiltinInjectionPointDecoratorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/injectionpoint/BuiltinInjectionPointDecoratorTest.java
@@ -32,6 +32,7 @@ import org.jboss.cdi.tck.tests.decorators.AbstractDecoratorTest;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
@@ -50,8 +51,7 @@ public class BuiltinInjectionPointDecoratorTest extends AbstractDecoratorTest {
                 .withTestClassPackage(BuiltinInjectionPointDecoratorTest.class)
                 .withClass(AbstractDecoratorTest.class)
                 .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateDecorators()
-                                .clazz(InjectionPointDecorator.class.getName()).up()).build();
+                        new BeansXml().decorators(InjectionPointDecorator.class)).build();
     }
 
     @Inject

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/instance/BuiltinInstanceDecoratorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/instance/BuiltinInstanceDecoratorTest.java
@@ -21,26 +21,24 @@ import static org.jboss.cdi.tck.cdi.Sections.DECORATOR_INVOCATION;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
-import java.lang.reflect.Type;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.util.TypeLiteral;
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.cdi.tck.tests.decorators.AbstractDecoratorTest;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
+
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 
 /**
  * Basic test for decorating built-in {@link Instance} bean.
@@ -57,8 +55,7 @@ public class BuiltinInstanceDecoratorTest extends AbstractDecoratorTest {
                 .withTestClassPackage(BuiltinInstanceDecoratorTest.class)
                 .withClass(AbstractDecoratorTest.class)
                 .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateDecorators()
-                                .clazz(MuleInstanceDecorator.class.getName()).up()).build();
+                        new BeansXml().decorators(MuleInstanceDecorator.class)).build();
     }
 
     @Inject

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/principal/BuiltinPrincipalDecoratorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/principal/BuiltinPrincipalDecoratorTest.java
@@ -21,22 +21,20 @@ import static org.jboss.cdi.tck.cdi.Sections.DECORATOR_BEAN_EE;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
-import java.lang.reflect.Type;
-import java.security.Principal;
-import java.util.Collections;
-
 import jakarta.inject.Inject;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.shrinkwrap.EnterpriseArchiveBuilder;
 import org.jboss.cdi.tck.tests.decorators.AbstractDecoratorTest;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
+
+import java.lang.reflect.Type;
+import java.security.Principal;
+import java.util.Collections;
 
 /**
  * 
@@ -52,8 +50,7 @@ public class BuiltinPrincipalDecoratorTest extends AbstractDecoratorTest {
                 .withTestClassPackage(BuiltinPrincipalDecoratorTest.class)
                 .withClass(AbstractDecoratorTest.class)
                 .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateDecorators().clazz(PrincipalDecorator.class.getName())
-                                .up()).build();
+                        new BeansXml().decorators(PrincipalDecorator.class)).build();
     }
 
     @Inject

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/transaction/BuiltinUserTransactionDecoratorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/transaction/BuiltinUserTransactionDecoratorTest.java
@@ -21,13 +21,11 @@ import static org.jboss.cdi.tck.cdi.Sections.DECORATOR_BEAN_EE;
 
 import jakarta.inject.Inject;
 import jakarta.transaction.Status;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.EnterpriseArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
@@ -51,8 +49,7 @@ public class BuiltinUserTransactionDecoratorTest extends AbstractTest {
         return new EnterpriseArchiveBuilder()
                 .withTestClassPackage(BuiltinUserTransactionDecoratorTest.class)
                 .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateDecorators()
-                                .clazz(UserTransactionDecorator.class.getName()).up()).build();
+                        new BeansXml().decorators(UserTransactionDecorator.class)).build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/custom/broken/finalBeanClass/CustomDecoratorMatchingBeanWithFinalClassTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/custom/broken/finalBeanClass/CustomDecoratorMatchingBeanWithFinalClassTest.java
@@ -27,6 +27,7 @@ import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -41,8 +42,8 @@ public class CustomDecoratorMatchingBeanWithFinalClassTest extends AbstractTest 
         return new WebArchiveBuilder()
                 .withTestClassPackage(CustomDecoratorMatchingBeanWithFinalClassTest.class)
                 .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateDecorators().clazz(VehicleDecorator.class.getName())
-                                .up()).withExtension(AfterBeanDiscoveryObserver.class).build();
+                        new BeansXml().decorators(VehicleDecorator.class))
+                .withExtension(AfterBeanDiscoveryObserver.class).build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/definition/DecoratorDefinitionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/definition/DecoratorDefinitionTest.java
@@ -30,27 +30,25 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
+import jakarta.decorator.Delegate;
+import jakarta.enterprise.inject.Default;
+import jakarta.enterprise.inject.spi.Decorator;
+import jakarta.enterprise.util.AnnotationLiteral;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.cdi.tck.AbstractTest;
+import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.impl.BeansXml;
+import org.jboss.test.audit.annotations.SpecAssertion;
+import org.jboss.test.audit.annotations.SpecAssertions;
+import org.jboss.test.audit.annotations.SpecVersion;
+import org.testng.annotations.Test;
+
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.HashSet;
 import java.util.List;
-
-import jakarta.decorator.Delegate;
-import jakarta.enterprise.inject.Default;
-import jakarta.enterprise.inject.spi.Decorator;
-import jakarta.enterprise.util.AnnotationLiteral;
-
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.cdi.tck.AbstractTest;
-import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
-import org.jboss.test.audit.annotations.SpecAssertion;
-import org.jboss.test.audit.annotations.SpecAssertions;
-import org.jboss.test.audit.annotations.SpecVersion;
-import org.testng.annotations.Test;
 
 /**
  * @author pmuir
@@ -64,13 +62,9 @@ public class DecoratorDefinitionTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder()
                 .withTestClassPackage(DecoratorDefinitionTest.class)
-                .withBeansXml(
-                        Descriptors
-                                .create(BeansDescriptor.class)
-                                .getOrCreateDecorators()
-                                .clazz(BazDecorator1.class.getName(), BazDecorator2.class.getName(),
-                                        FooDecorator.class.getName(), TimestampLogger.class.getName(),
-                                        ChargeDecorator.class.getName()).up()).build();
+                .withBeansXml(new BeansXml().decorators(BazDecorator1.class, BazDecorator2.class,
+                        FooDecorator.class, TimestampLogger.class,
+                        ChargeDecorator.class)).build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/definition/broken/decoratorListedTwiceInBeansXml/DecoratorListedTwiceInBeansXmlTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/definition/broken/decoratorListedTwiceInBeansXml/DecoratorListedTwiceInBeansXmlTest.java
@@ -27,6 +27,7 @@ import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -45,8 +46,7 @@ public class DecoratorListedTwiceInBeansXmlTest extends AbstractTest {
         return new WebArchiveBuilder()
                 .withTestClassPackage(DecoratorListedTwiceInBeansXmlTest.class)
                 .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateDecorators()
-                                .clazz(PresentDecorator.class.getName(), PresentDecorator.class.getName()).up()).build();
+                        new BeansXml().decorators(PresentDecorator.class, PresentDecorator.class)).build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/definition/broken/enabledDecoratorIsNotDecorator/EnabledDecoratorNotADecoratorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/definition/broken/enabledDecoratorIsNotDecorator/EnabledDecoratorNotADecoratorTest.java
@@ -19,14 +19,12 @@ package org.jboss.cdi.tck.tests.decorators.definition.broken.enabledDecoratorIsN
 import static org.jboss.cdi.tck.cdi.Sections.ENABLED_DECORATORS_BEAN_ARCHIVE;
 
 import jakarta.enterprise.inject.spi.DeploymentException;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -44,8 +42,7 @@ public class EnabledDecoratorNotADecoratorTest extends AbstractTest {
         return new WebArchiveBuilder()
                 .withTestClassPackage(EnabledDecoratorNotADecoratorTest.class)
                 .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateDecorators().clazz(TimestampLogger.class.getName())
-                                .up()).build();
+                        new BeansXml().decorators(TimestampLogger.class)).build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/definition/broken/finalBeanClass/FinalBeanClassTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/definition/broken/finalBeanClass/FinalBeanClassTest.java
@@ -19,14 +19,12 @@ package org.jboss.cdi.tck.tests.decorators.definition.broken.finalBeanClass;
 import static org.jboss.cdi.tck.cdi.Sections.DECORATOR_RESOLUTION;
 
 import jakarta.enterprise.inject.spi.DeploymentException;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -44,8 +42,7 @@ public class FinalBeanClassTest extends AbstractTest {
         return new WebArchiveBuilder()
                 .withTestClassPackage(FinalBeanClassTest.class)
                 .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateDecorators().clazz(TimestampLogger.class.getName())
-                                .up()).build();
+                        new BeansXml().decorators(TimestampLogger.class)).build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/definition/broken/finalBeanMethod/FinalBeanMethodTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/definition/broken/finalBeanMethod/FinalBeanMethodTest.java
@@ -27,6 +27,7 @@ import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -44,8 +45,8 @@ public class FinalBeanMethodTest extends AbstractTest {
         return new WebArchiveBuilder()
                 .withTestClassPackage(FinalBeanMethodTest.class)
                 .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateDecorators().clazz(TimestampLogger.class.getName())
-                                .up()).build();
+                        new BeansXml().decorators(TimestampLogger.class))
+                .build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/definition/broken/invalidAbstractMethodOnDecorator/DecoratorWithInvalidAbstractMethodTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/definition/broken/invalidAbstractMethodOnDecorator/DecoratorWithInvalidAbstractMethodTest.java
@@ -27,6 +27,7 @@ import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -46,7 +47,7 @@ public class DecoratorWithInvalidAbstractMethodTest extends AbstractTest {
         return new WebArchiveBuilder()
                 .withTestClassPackage(DecoratorWithInvalidAbstractMethodTest.class)
                 .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateDecorators().clazz(ThiefDecorator.class.getName()).up())
+                        new BeansXml().decorators(ThiefDecorator.class))
                 .build();
     }
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/definition/broken/multipleDelegateInjectionPoints/MultipleDelegateInjectionPointsTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/definition/broken/multipleDelegateInjectionPoints/MultipleDelegateInjectionPointsTest.java
@@ -27,6 +27,7 @@ import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -44,8 +45,7 @@ public class MultipleDelegateInjectionPointsTest extends AbstractTest {
         return new WebArchiveBuilder()
                 .withTestClassPackage(MultipleDelegateInjectionPointsTest.class)
                 .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateDecorators().clazz(TimestampLogger.class.getName())
-                                .up()).build();
+                        new BeansXml().decorators(TimestampLogger.class)).build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/definition/broken/noDelegateInjectionPoints/NoDelegateInjectionPointsTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/definition/broken/noDelegateInjectionPoints/NoDelegateInjectionPointsTest.java
@@ -19,14 +19,12 @@ package org.jboss.cdi.tck.tests.decorators.definition.broken.noDelegateInjection
 import static org.jboss.cdi.tck.cdi.Sections.DELEGATE_ATTRIBUTE;
 
 import jakarta.enterprise.inject.spi.DefinitionException;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -44,8 +42,7 @@ public class NoDelegateInjectionPointsTest extends AbstractTest {
         return new WebArchiveBuilder()
                 .withTestClassPackage(NoDelegateInjectionPointsTest.class)
                 .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateDecorators().clazz(TimestampLogger.class.getName())
-                                .up()).build();
+                        new BeansXml().decorators(TimestampLogger.class)).build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/definition/broken/nodecoratedtypes/DecoratorWithNoDecoratedTypes2Test.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/definition/broken/nodecoratedtypes/DecoratorWithNoDecoratedTypes2Test.java
@@ -19,14 +19,12 @@ package org.jboss.cdi.tck.tests.decorators.definition.broken.nodecoratedtypes;
 import static org.jboss.cdi.tck.cdi.Sections.DECORATOR_BEAN;
 
 import jakarta.enterprise.inject.spi.DefinitionException;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -49,7 +47,7 @@ public class DecoratorWithNoDecoratedTypes2Test extends AbstractTest {
                 .withTestClass(DecoratorWithNoDecoratedTypes1Test.class)
                 .withClasses(Foo.class, FooDecorator.class)
                 .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateDecorators().clazz(FooDecorator.class.getName()).up())
+                        new BeansXml().decorators(FooDecorator.class))
                 .build();
     }
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/definition/broken/nonExistantClassInBeansXml/NonExistantDecoratorClassInBeansXmlTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/definition/broken/nonExistantClassInBeansXml/NonExistantDecoratorClassInBeansXmlTest.java
@@ -19,14 +19,11 @@ package org.jboss.cdi.tck.tests.decorators.definition.broken.nonExistantClassInB
 import static org.jboss.cdi.tck.cdi.Sections.ENABLED_DECORATORS_BEAN_ARCHIVE;
 
 import jakarta.enterprise.inject.spi.DeploymentException;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -39,9 +36,8 @@ public class NonExistantDecoratorClassInBeansXmlTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder()
                 .withTestClassPackage(NonExistantDecoratorClassInBeansXmlTest.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateDecorators()
-                                .clazz("com.acme.NonExistantDecoratorClass").up()).build();
+                .withBeansXml("beans.xml")
+                .build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/definition/broken/notAllDecoratedTypesImplemented/NotAllDecoratedTypesImplementedTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/definition/broken/notAllDecoratedTypesImplemented/NotAllDecoratedTypesImplementedTest.java
@@ -19,14 +19,12 @@ package org.jboss.cdi.tck.tests.decorators.definition.broken.notAllDecoratedType
 import static org.jboss.cdi.tck.cdi.Sections.DECORATED_TYPES;
 
 import jakarta.enterprise.inject.spi.DefinitionException;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -44,8 +42,7 @@ public class NotAllDecoratedTypesImplementedTest extends AbstractTest {
         return new WebArchiveBuilder()
                 .withTestClassPackage(NotAllDecoratedTypesImplementedTest.class)
                 .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateDecorators().clazz(TimestampLogger.class.getName())
-                                .up()).build();
+                        new BeansXml().decorators(TimestampLogger.class)).build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/definition/broken/notAllDecoratedTypesImplemented/parameterized/TypeParametersNotTheSameTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/definition/broken/notAllDecoratedTypesImplemented/parameterized/TypeParametersNotTheSameTest.java
@@ -28,6 +28,7 @@ import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
@@ -46,8 +47,7 @@ public class TypeParametersNotTheSameTest extends AbstractTest {
         return new WebArchiveBuilder()
                 .withTestClassPackage(TypeParametersNotTheSameTest.class)
                 .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateDecorators().clazz(TimestampLogger.class.getName())
-                                .up()).build();
+                        new BeansXml().decorators(TimestampLogger.class)).build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/definition/broken/observer/DecoratorWithAsyncObserverMethodTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/definition/broken/observer/DecoratorWithAsyncObserverMethodTest.java
@@ -27,6 +27,7 @@ import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -41,8 +42,7 @@ public class DecoratorWithAsyncObserverMethodTest extends AbstractTest {
                 .withClasses(ApplicationLogger.class, FooPayload.class, Logger.class, MockLogger.class)
                 .withTestClass(DecoratorWithAsyncObserverMethodTest.class)
                 .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateDecorators().clazz(ApplicationLogger.class.getName())
-                                .up()).build();
+                        new BeansXml().decorators(ApplicationLogger.class)).build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/definition/broken/observer/DecoratorWithObserverMethodTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/definition/broken/observer/DecoratorWithObserverMethodTest.java
@@ -27,6 +27,7 @@ import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -46,8 +47,7 @@ public class DecoratorWithObserverMethodTest extends AbstractTest {
                 .withClasses(FilesystemLogger.class, FooPayload.class, Logger.class, MockLogger.class)
                 .withTestClass(DecoratorWithObserverMethodTest.class)
                 .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateDecorators().clazz(FilesystemLogger.class.getName())
-                                .up()).build();
+                        new BeansXml().decorators(FilesystemLogger.class)).build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/definition/broken/parameterizedTypesWithDifferentTypeParameters/DifferentTypeParametersTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/definition/broken/parameterizedTypesWithDifferentTypeParameters/DifferentTypeParametersTest.java
@@ -19,14 +19,12 @@ package org.jboss.cdi.tck.tests.decorators.definition.broken.parameterizedTypesW
 import static org.jboss.cdi.tck.cdi.Sections.DECORATED_TYPES;
 
 import jakarta.enterprise.inject.spi.DefinitionException;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -44,7 +42,7 @@ public class DifferentTypeParametersTest extends AbstractTest {
         return new WebArchiveBuilder()
                 .withTestClassPackage(DifferentTypeParametersTest.class)
                 .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateDecorators().clazz(RadioDecorator.class.getName()).up())
+                        new BeansXml().decorators(RadioDecorator.class))
                 .build();
     }
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/definition/lifecycle/DecoratorInstanceIsDependentObjectTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/definition/lifecycle/DecoratorInstanceIsDependentObjectTest.java
@@ -20,22 +20,20 @@ import static org.jboss.cdi.tck.TestGroups.INTEGRATION;
 import static org.jboss.cdi.tck.cdi.Sections.DECORATORS;
 import static org.testng.Assert.assertTrue;
 
-import java.net.URL;
-
+import com.gargoylesoftware.htmlunit.TextPage;
+import com.gargoylesoftware.htmlunit.WebClient;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
 
-import com.gargoylesoftware.htmlunit.TextPage;
-import com.gargoylesoftware.htmlunit.WebClient;
+import java.net.URL;
 
 /**
  * 
@@ -53,8 +51,7 @@ public class DecoratorInstanceIsDependentObjectTest extends AbstractTest {
         return new WebArchiveBuilder()
                 .withTestClassPackage(DecoratorInstanceIsDependentObjectTest.class)
                 .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateDecorators().clazz(ChargeDecorator.class.getName())
-                                .up()).build();
+                        new BeansXml().decorators(ChargeDecorator.class)).build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/definition/producer/DecoratorNotAppliedToResultOfProducerTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/definition/producer/DecoratorNotAppliedToResultOfProducerTest.java
@@ -25,8 +25,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -43,8 +42,7 @@ public class DecoratorNotAppliedToResultOfProducerTest extends AbstractTest {
         return new WebArchiveBuilder()
                 .withTestClassPackage(DecoratorNotAppliedToResultOfProducerTest.class)
                 .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateDecorators().clazz(ChargeDecorator.class.getName())
-                                .up()).build();
+                        new BeansXml().decorators(ChargeDecorator.class)).build();
     }
 
     @Test(dataProvider = ARQUILLIAN_DATA_PROVIDER)

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/definition/types/DelegateTypeImplementsParameterizedDecoratedTypeTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/definition/types/DelegateTypeImplementsParameterizedDecoratedTypeTest.java
@@ -21,13 +21,11 @@ import static org.jboss.cdi.tck.cdi.Sections.DECORATED_TYPES;
 import static org.testng.Assert.assertEquals;
 
 import jakarta.inject.Inject;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
@@ -45,8 +43,7 @@ public class DelegateTypeImplementsParameterizedDecoratedTypeTest extends Abstra
         return new WebArchiveBuilder()
                 .withTestClassPackage(DelegateTypeImplementsParameterizedDecoratedTypeTest.class)
                 .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateDecorators().clazz(TimestampLogger.class.getName())
-                                .up()).build();
+                        new BeansXml().decorators(TimestampLogger.class)).build();
     }
 
     @Inject

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/interceptor/DecoratorAndInterceptorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/interceptor/DecoratorAndInterceptorTest.java
@@ -33,6 +33,7 @@ import org.jboss.cdi.tck.util.ActionSequence;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
@@ -46,9 +47,8 @@ public class DecoratorAndInterceptorTest extends AbstractTest {
         return new WebArchiveBuilder()
                 .withTestClassPackage(DecoratorAndInterceptorTest.class)
                 .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors()
-                                .clazz(FooInterceptor1.class.getName(), FooInterceptor2.class.getName()).up()
-                                .getOrCreateDecorators().clazz(FooDecorator1.class.getName(), FooDecorator2.class.getName()).up())
+                        new BeansXml().interceptors(FooInterceptor1.class, FooInterceptor2.class)
+                            .decorators(FooDecorator1.class, FooDecorator2.class))
                 .build();
     }
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/invocation/DecoratorInvocationTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/invocation/DecoratorInvocationTest.java
@@ -25,8 +25,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
@@ -45,12 +44,8 @@ public class DecoratorInvocationTest extends AbstractTest {
                 .withTestClassPackage(DecoratorInvocationTest.class)
                 .withExcludedClasses(EJBDecoratorInvocationTest.class.getName(), PigSty.class.getName(),
                         PigStyImpl.class.getName(), PigStyDecorator.class.getName(), Pig.class.getName())
-                .withBeansXml(
-                        Descriptors
-                                .create(BeansDescriptor.class)
-                                .getOrCreateDecorators()
-                                .clazz(BarDecorator.class.getName(), FooDecorator1.class.getName(),
-                                        FooDecorator2.class.getName(), TimestampLogger.class.getName()).up()).build();
+                .withBeansXml(new BeansXml().decorators(BarDecorator.class, FooDecorator1.class, FooDecorator2.class, TimestampLogger.class))
+                .build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/invocation/EJBDecoratorInvocationTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/invocation/EJBDecoratorInvocationTest.java
@@ -22,13 +22,11 @@ import static org.jboss.cdi.tck.cdi.Sections.DECORATOR_BEAN_EE;
 import static org.testng.Assert.assertTrue;
 
 import jakarta.inject.Inject;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
@@ -47,8 +45,8 @@ public class EJBDecoratorInvocationTest extends AbstractTest {
                 .withTestClass(EJBDecoratorInvocationTest.class)
                 .withClasses(PigSty.class, PigStyImpl.class, PigStyDecorator.class, Pig.class)
                 .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateDecorators().clazz(PigStyDecorator.class.getName())
-                                .up()).build();
+                        new BeansXml().decorators(PigStyDecorator.class))
+                .build();
     }
 
     @Inject

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/invocation/enterprise/EnterpriseDecoratorInvocationTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/invocation/enterprise/EnterpriseDecoratorInvocationTest.java
@@ -24,24 +24,22 @@ import static org.jboss.cdi.tck.cdi.Sections.DECORATOR_BEAN_EE;
 import static org.jboss.cdi.tck.cdi.Sections.DELEGATE_ATTRIBUTE;
 import static org.testng.Assert.assertEquals;
 
-import java.lang.reflect.Type;
-import java.util.Collections;
-import java.util.List;
-
 import jakarta.enterprise.inject.spi.Decorator;
 import jakarta.inject.Inject;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.cdi.tck.util.ActionSequence;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
+
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.List;
 
 /**
  *
@@ -55,15 +53,10 @@ public class EnterpriseDecoratorInvocationTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder()
                 .withTestClassPackage(EnterpriseDecoratorInvocationTest.class)
-                .withBeansXml(
-                        Descriptors
-                                .create(BeansDescriptor.class)
-                                .getOrCreateInterceptors()
-                                .clazz(FooInterceptor.class.getName())
-                                .up()
-                                .getOrCreateDecorators()
-                                .clazz(FooBusinessDecorator1.class.getName(), FooBusinessDecorator2.class.getName(),
-                                        BarBusinessDecorator.class.getName()).up()).build();
+                .withBeansXml(new BeansXml()
+                        .interceptors(FooInterceptor.class)
+                        .decorators(FooBusinessDecorator1.class, FooBusinessDecorator2.class, BarBusinessDecorator.class))
+                .build();
     }
 
     @Inject

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/ordering/global/EnterpriseDecoratorOrderingTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/ordering/global/EnterpriseDecoratorOrderingTest.java
@@ -37,6 +37,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
 import org.jboss.shrinkwrap.descriptor.api.spec.se.manifest.ManifestDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
@@ -47,7 +48,7 @@ import org.testng.annotations.Test;
  * @author Matus Abaffy
  */
 @SpecVersion(spec = "cdi", version = "2.0")
-public class EnterpriseDecoratorOrderingTest extends AbstractTest {
+    public class EnterpriseDecoratorOrderingTest extends AbstractTest {
 
     /**
      * Modules:
@@ -74,8 +75,7 @@ public class EnterpriseDecoratorOrderingTest extends AbstractTest {
                 //A - default test-ejb.jar
                 .withTestClassDefinition(EnterpriseDecoratorOrderingTest.class)
                 .withClasses(DecoratedImpl.class, LegacyDecorator2.class)
-                .withBeansXml(Descriptors.create(BeansDescriptor.class)
-                        .getOrCreateDecorators().clazz(LegacyDecorator2.class.getName()).up())
+                .withBeansXml(new BeansXml().decorators(LegacyDecorator2.class))
                 //B
                 .withBeanLibrary(Decorated.class, GloballyEnabledDecorator3.class)
                 //C
@@ -86,9 +86,7 @@ public class EnterpriseDecoratorOrderingTest extends AbstractTest {
         JavaArchive ejbArchive = ShrinkWrap
                 .create(JavaArchive.class, ejbJar)
                 .addClasses(DummyDao.class, GloballyEnabledDecorator2.class, GloballyEnabledDecorator5.class, LegacyDecorator3.class)
-                .addAsManifestResource(
-                        new StringAsset(Descriptors.create(BeansDescriptor.class).getOrCreateDecorators()
-                                .clazz(LegacyDecorator3.class.getName()).up().exportAsString()), "beans.xml")
+                .addAsManifestResource(new BeansXml().decorators(LegacyDecorator3.class), "beans.xml")
                 .setManifest(
                         new StringAsset(Descriptors.create(ManifestDescriptor.class)
                                 .addToClassPath(EnterpriseArchiveBuilder.DEFAULT_EJB_MODULE_NAME)
@@ -100,8 +98,7 @@ public class EnterpriseDecoratorOrderingTest extends AbstractTest {
                 .notTestArchive()
                 //F
                 .withClasses(EnterpriseDecoratorOrderingTest.class, GloballyEnabledDecorator1.class, LegacyDecorator1.class)
-                .withBeansXml(Descriptors.create(BeansDescriptor.class)
-                        .getOrCreateDecorators().clazz(LegacyDecorator1.class.getName()).up())
+                .withBeansXml(new BeansXml().decorators(LegacyDecorator1.class))
                 //G
                 .withBeanLibrary(GloballyEnabledDecorator4.class)
                 .build()

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/ordering/global/GlobalDecoratorOrderingTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/decorators/ordering/global/GlobalDecoratorOrderingTest.java
@@ -21,21 +21,19 @@ import static org.jboss.cdi.tck.cdi.Sections.ENABLED_DECORATORS_BEAN_ARCHIVE;
 import static org.jboss.cdi.tck.cdi.Sections.ENABLED_DECORATORS_PRIORITY;
 import static org.testng.Assert.assertEquals;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import jakarta.inject.Inject;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * <p>
@@ -55,12 +53,7 @@ public class GlobalDecoratorOrderingTest extends AbstractTest {
                 .withTestClass(GlobalDecoratorOrderingTest.class)
                 .withClasses(DecoratedImpl.class, LegacyDecorator1.class, LegacyDecorator2.class, LegacyDecorator3.class,
                         WebApplicationGlobalDecorator.class)
-                .withBeansXml(
-                        Descriptors
-                                .create(BeansDescriptor.class)
-                                .getOrCreateDecorators()
-                                .clazz(LegacyDecorator1.class.getName(), LegacyDecorator2.class.getName(),
-                                        LegacyDecorator3.class.getName()).up())
+                .withBeansXml(new BeansXml().decorators(LegacyDecorator1.class, LegacyDecorator2.class, LegacyDecorator3.class))
                 .withBeanLibrary(AbstractDecorator.class, Decorated.class, GloballyEnabledDecorator1.class,
                         GloballyEnabledDecorator2.class, GloballyEnabledDecorator3.class, GloballyEnabledDecorator4.class,
                         GloballyEnabledDecorator5.class).build();

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/alternative/enterprise/EnterpriseStereotypeAlternativeSpecializeTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/alternative/enterprise/EnterpriseStereotypeAlternativeSpecializeTest.java
@@ -28,6 +28,7 @@ import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
@@ -46,8 +47,7 @@ public class EnterpriseStereotypeAlternativeSpecializeTest extends AbstractTest 
         return new WebArchiveBuilder()
                 .withTestClass(EnterpriseStereotypeAlternativeSpecializeTest.class)
                 .withClasses(Mock.class, Service.class, MockService.class, RealService.class, AbstractService.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateAlternatives().stereotype(Mock.class.getName()).up())
+                .withBeansXml(new BeansXml().stereotype(Mock.class))
                 .build();
     }
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/alternative/enterprise/EnterpriseStereotypeAlternativeTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/alternative/enterprise/EnterpriseStereotypeAlternativeTest.java
@@ -28,6 +28,7 @@ import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
@@ -46,8 +47,7 @@ public class EnterpriseStereotypeAlternativeTest extends AbstractTest {
         return new WebArchiveBuilder()
                 .withTestClass(EnterpriseStereotypeAlternativeTest.class)
                 .withClasses(Mock.class, SimpleAlternativeService.class, Service.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateAlternatives().stereotype(Mock.class.getName()).up())
+                .withBeansXml(new BeansXml().stereotype(Mock.class))
                 .build();
     }
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/interceptor/StereotypeWithMultipleInterceptorBindingsTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/interceptor/StereotypeWithMultipleInterceptorBindingsTest.java
@@ -25,8 +25,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
@@ -43,9 +42,7 @@ public class StereotypeWithMultipleInterceptorBindingsTest extends AbstractTest 
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder()
                 .withTestClassPackage(StereotypeWithMultipleInterceptorBindingsTest.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors()
-                                .clazz(AlphaInterceptor.class.getName(), OmegaInterceptor.class.getName()).up()).build();
+                .withBeansXml(new BeansXml().interceptors(AlphaInterceptor.class, OmegaInterceptor.class)).build();
     }
 
     @Test(dataProvider = ARQUILLIAN_DATA_PROVIDER)

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/interceptor/enterprise/EnterpriseStereotypeInterceptorBindingTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/interceptor/enterprise/EnterpriseStereotypeInterceptorBindingTest.java
@@ -20,13 +20,11 @@ import static org.jboss.cdi.tck.TestGroups.INTEGRATION;
 import static org.jboss.cdi.tck.cdi.Sections.INTERCEPTORS_EE;
 
 import jakarta.inject.Inject;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
@@ -45,9 +43,7 @@ public class EnterpriseStereotypeInterceptorBindingTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder()
                 .withTestClassPackage(EnterpriseStereotypeInterceptorBindingTest.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors().clazz(AlphaInterceptor.class.getName())
-                                .up()).build();
+                .withBeansXml(new BeansXml().interceptors(AlphaInterceptor.class)).build();
     }
 
     @Inject

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/Alpha2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/Alpha2.java
@@ -1,0 +1,8 @@
+package org.jboss.cdi.tck.tests.deployment.discovery;
+
+public class Alpha2 implements Ping {
+
+    @Override
+    public void pong() {
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/Alpha3.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/Alpha3.java
@@ -1,0 +1,8 @@
+package org.jboss.cdi.tck.tests.deployment.discovery;
+
+public class Alpha3 implements Ping {
+
+    @Override
+    public void pong() {
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/BeanDiscoveryTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/BeanDiscoveryTest.java
@@ -30,6 +30,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.BeanDiscoveryMode;
+import org.jboss.shrinkwrap.api.BeansXmlVersion;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -56,6 +57,16 @@ public class BeanDiscoveryTest extends AbstractTest {
                 .create(JavaArchive.class)
                 .addClass(Alpha.class)
                 .addAsManifestResource(new BeansXml(BeanDiscoveryMode.ALL), "beans.xml");
+        // beans.xml with version 1.1 and bean-discovery-mode of all
+        JavaArchive alpha2 = ShrinkWrap
+                .create(JavaArchive.class)
+                .addClass(Alpha2.class)
+                .addAsManifestResource(new BeansXml(BeanDiscoveryMode.ALL).setBeansXmlVersion(BeansXmlVersion.v11), "beans.xml");
+        // beans.xml with version 2.0 and bean-discovery-mode of all
+        JavaArchive alpha3 = ShrinkWrap
+                .create(JavaArchive.class)
+                .addClass(Alpha3.class)
+                .addAsManifestResource(new BeansXml(BeanDiscoveryMode.ALL).setBeansXmlVersion(BeansXmlVersion.v20), "beans.xml");
         // Empty beans.xml
         JavaArchive bravo = ShrinkWrap.create(JavaArchive.class).addClass(Bravo.class)
                 .addAsManifestResource(new StringAsset(""), "beans.xml");
@@ -87,7 +98,7 @@ public class BeanDiscoveryTest extends AbstractTest {
                 .withClasses(VerifyingExtension.class, ScopesExtension.class, Binding.class, MyNormalScope.class, MyPseudoScope.class,
                         MyNormalContext.class, MyPseudoContext.class, MyStereotype.class)
                 .withExtensions(VerifyingExtension.class, ScopesExtension.class).withLibrary(Ping.class)
-                .withLibraries(alpha, bravo, charlie, delta, echo, foxtrot, legacy).build();
+                .withLibraries(alpha, alpha2, alpha3, bravo, charlie, delta, echo, foxtrot, legacy).build();
     }
 
     @Inject
@@ -97,6 +108,18 @@ public class BeanDiscoveryTest extends AbstractTest {
     @SpecAssertions({ @SpecAssertion(section = BEAN_ARCHIVE, id = "ba"), @SpecAssertion(section = TYPE_DISCOVERY_STEPS, id = "a") })
     public void testExplicitBeanArchiveModeAll(Alpha alpha) {
         assertDiscoveredAndAvailable(alpha, Alpha.class);
+    }
+
+    @Test(dataProvider = ARQUILLIAN_DATA_PROVIDER)
+    @SpecAssertions({ @SpecAssertion(section = BEAN_ARCHIVE, id = "ba"), @SpecAssertion(section = TYPE_DISCOVERY_STEPS, id = "a") })
+    public void testExplicitBeanArchiveModeAllVersion11(Alpha2 alpha) {
+        assertDiscoveredAndAvailable(alpha, Alpha2.class);
+    }
+
+    @Test(dataProvider = ARQUILLIAN_DATA_PROVIDER)
+    @SpecAssertions({ @SpecAssertion(section = BEAN_ARCHIVE, id = "ba"), @SpecAssertion(section = TYPE_DISCOVERY_STEPS, id = "a") })
+    public void testExplicitBeanArchiveModeAllVersion20(Alpha3 alpha) {
+        assertDiscoveredAndAvailable(alpha, Alpha3.class);
     }
 
     @Test(dataProvider = ARQUILLIAN_DATA_PROVIDER)

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/BeanDiscoveryTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/BeanDiscoveryTest.java
@@ -26,18 +26,15 @@ import static org.testng.Assert.assertTrue;
 
 import jakarta.enterprise.inject.spi.Extension;
 import jakarta.inject.Inject;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
-import org.jboss.cdi.tck.util.Versions;
+import org.jboss.shrinkwrap.api.BeanDiscoveryMode;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeanDiscoveryMode;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
@@ -54,13 +51,11 @@ public class BeanDiscoveryTest extends AbstractTest {
     @Deployment
     public static WebArchive createTestArchive() {
 
-        // 1.1 version beans.xml with bean-discovery-mode of all
+        // beans.xml with bean-discovery-mode of all
         JavaArchive alpha = ShrinkWrap
                 .create(JavaArchive.class)
                 .addClass(Alpha.class)
-                .addAsManifestResource(
-                        new StringAsset(Descriptors.create(BeansDescriptor.class).beanDiscoveryMode(BeanDiscoveryMode._ALL.toString()).exportAsString()),
-                        "beans.xml");
+                .addAsManifestResource(new BeansXml(BeanDiscoveryMode.ALL), "beans.xml");
         // Empty beans.xml
         JavaArchive bravo = ShrinkWrap.create(JavaArchive.class).addClass(Bravo.class)
                 .addAsManifestResource(new StringAsset(""), "beans.xml");
@@ -68,26 +63,21 @@ public class BeanDiscoveryTest extends AbstractTest {
         JavaArchive charlie = ShrinkWrap
                 .create(JavaArchive.class)
                 .addClass(Charlie.class)
-                .addAsManifestResource(new StringAsset(Descriptors.create(BeansDescriptor.class).beanDiscoveryMode(BeanDiscoveryMode._ALL.toString()).version(
-                        Versions.v1_1).exportAsString()), "beans.xml");
+                .addAsManifestResource(new BeansXml(BeanDiscoveryMode.ALL),"beans.xml");
         // Bean defining annotation and no beans.xml
         JavaArchive delta = ShrinkWrap.create(JavaArchive.class).addClasses(Delta.class, Golf.class, India.class, Kilo.class,
                 Mike.class, Interceptor1.class, Decorator1.class);
-        // Bean defining annotation and 1.1 version beans.xml with bean-discovery-mode of annotated
+        // Bean defining annotation and beans.xml with bean-discovery-mode of annotated
         JavaArchive echo = ShrinkWrap
                 .create(JavaArchive.class)
                 .addClasses(Echo.class, EchoNotABean.class, Hotel.class, Juliet.class, JulietNotABean.class, Lima.class,
                         November.class, Interceptor2.class, Decorator2.class)
-                .addAsManifestResource(
-                        new StringAsset(Descriptors.create(BeansDescriptor.class).beanDiscoveryMode(BeanDiscoveryMode._ANNOTATED.toString()).exportAsString()),
-                        "beans.xml");
-        // Bean defining annotation and 1.1 version beans.xml with bean-discovery-mode of none
+                .addAsManifestResource(new BeansXml(BeanDiscoveryMode.ANNOTATED), "beans.xml");
+        // Bean defining annotation and beans.xml with bean-discovery-mode of none
         JavaArchive foxtrot = ShrinkWrap
                 .create(JavaArchive.class)
                 .addClass(Foxtrot.class)
-                .addAsManifestResource(
-                        new StringAsset(Descriptors.create(BeansDescriptor.class).beanDiscoveryMode(BeanDiscoveryMode._NONE.toString()).exportAsString()),
-                        "beans.xml");
+                .addAsManifestResource(new BeansXml(BeanDiscoveryMode.NONE), "beans.xml");
 
         // Archive which contains an extension and no beans.xml file
         JavaArchive legacy = ShrinkWrap.create(JavaArchive.class).addClasses(LegacyExtension.class, LegacyAlpha.class,

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/enterprise/EnterpriseBeanDiscoveryTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/enterprise/EnterpriseBeanDiscoveryTest.java
@@ -27,20 +27,19 @@ import static org.testng.Assert.assertTrue;
 
 import jakarta.enterprise.inject.spi.Extension;
 import jakarta.inject.Inject;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.EnterpriseArchiveBuilder;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
+import org.jboss.shrinkwrap.api.BeanDiscoveryMode;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeanDiscoveryMode;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
 import org.jboss.shrinkwrap.descriptor.api.spec.se.manifest.ManifestDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
@@ -63,13 +62,11 @@ public class EnterpriseBeanDiscoveryTest extends AbstractTest {
     @Deployment
     public static EnterpriseArchive createTestArchive() {
 
-        // 1.1 version beans.xml with bean-discovery-mode of all
+        // beans.xml with bean-discovery-mode of all
         JavaArchive alpha = ShrinkWrap
                 .create(JavaArchive.class, ALPHA_JAR)
                 .addClasses(Alpha.class, AlphaLocal.class)
-                .addAsManifestResource(
-                        new StringAsset(Descriptors.create(BeansDescriptor.class).beanDiscoveryMode(BeanDiscoveryMode._ALL.toString()).exportAsString()),
-                        "beans.xml");
+                .addAsManifestResource(new BeansXml(BeanDiscoveryMode.ALL), "beans.xml");
         // Empty beans.xml
         JavaArchive bravo = ShrinkWrap.create(JavaArchive.class, BRAVO_JAR).addClasses(Bravo.class, BravoLocal.class)
                 .addAsManifestResource(new StringAsset(""), "beans.xml");
@@ -77,23 +74,20 @@ public class EnterpriseBeanDiscoveryTest extends AbstractTest {
         JavaArchive charlie = ShrinkWrap
                 .create(JavaArchive.class, CHARLIE_JAR)
                 .addClasses(Charlie.class, CharlieLocal.class)
-                .addAsManifestResource(new StringAsset(Descriptors.create(BeansDescriptor.class).exportAsString()), "beans.xml");
+                // add path to pre-created beans.xml
+                .addAsManifestResource(EnterpriseBeanDiscoveryTest.class.getPackage().getName().replace('.', '/').concat("/") + "beans.xml");
         // Session bean and no beans.xml
         JavaArchive delta = ShrinkWrap.create(JavaArchive.class, DELTA_JAR).addClasses(Delta.class, DeltaLocal.class);
-        // Session bean and 1.1 version beans.xml with bean-discovery-mode of annotated
+        // Session bean and beans.xml with bean-discovery-mode of annotated
         JavaArchive echo = ShrinkWrap
                 .create(JavaArchive.class, ECHO_JAR)
                 .addClasses(Echo.class, EchoLocal.class)
-                .addAsManifestResource(
-                        new StringAsset(Descriptors.create(BeansDescriptor.class).beanDiscoveryMode(BeanDiscoveryMode._ANNOTATED.toString()).exportAsString()),
-                        "beans.xml");
-        // Session bean and 1.1 version beans.xml with bean-discovery-mode of none
+                .addAsManifestResource(new BeansXml(BeanDiscoveryMode.ANNOTATED), "beans.xml");
+        // Session bean and beans.xml with bean-discovery-mode of none
         JavaArchive foxtrot = ShrinkWrap
                 .create(JavaArchive.class, FOXTROT_JAR)
                 .addClasses(Foxtrot.class, FoxtrotLocal.class)
-                .addAsManifestResource(
-                        new StringAsset(Descriptors.create(BeansDescriptor.class).beanDiscoveryMode(BeanDiscoveryMode._NONE.toString()).exportAsString()),
-                        "beans.xml");
+                .addAsManifestResource(new BeansXml(BeanDiscoveryMode.NONE), "beans.xml");
 
         // Archive which contains an extension and no beans.xml file - not a bean archive
         JavaArchive legacy = ShrinkWrap.create(JavaArchive.class, LEGACY_JAR)

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/enterprise/annotated/EnterpriseDefaultBeanDiscoveryModeTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/enterprise/annotated/EnterpriseDefaultBeanDiscoveryModeTest.java
@@ -22,22 +22,20 @@ import static org.jboss.cdi.tck.cdi.Sections.DEFAULT_BEAN_DISCOVERY_EE;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
-import java.util.Set;
-
 import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.enterprise.inject.spi.ObserverMethod;
 import jakarta.inject.Inject;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
+import org.jboss.shrinkwrap.api.BeanDiscoveryMode;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeanDiscoveryMode;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
+
+import java.util.Set;
 
 @Test(groups = { JAVAEE_FULL, INTEGRATION })
 @SpecVersion(spec = "cdi", version = "2.0")
@@ -52,8 +50,8 @@ public class EnterpriseDefaultBeanDiscoveryModeTest extends AbstractTest {
     @Deployment
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder().withTestClassPackage(EnterpriseDefaultBeanDiscoveryModeTest.class)
-                .withBeansXml(Descriptors.create(BeansDescriptor.class).beanDiscoveryMode(BeanDiscoveryMode._ANNOTATED.toString())).withExtension(
-                        TestExtension.class).build();
+                .withBeansXml(new BeansXml(BeanDiscoveryMode.ANNOTATED))
+                .withExtension(TestExtension.class).build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/implicit/DefaultBeanDiscoveryModeTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/implicit/DefaultBeanDiscoveryModeTest.java
@@ -32,10 +32,10 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.TestGroups;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
+import org.jboss.shrinkwrap.api.BeanDiscoveryMode;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeanDiscoveryMode;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -53,8 +53,7 @@ public class DefaultBeanDiscoveryModeTest extends AbstractTest {
     @Deployment
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder()
-            .withBeansXml(Descriptors.create(BeansDescriptor.class)
-                .beanDiscoveryMode(BeanDiscoveryMode._ANNOTATED.toString()).version("2.0"))
+            .withBeansXml(new BeansXml(BeanDiscoveryMode.ANNOTATED))
             .withTestClass(DefaultBeanDiscoveryModeTest.class)
             .withExtension(TestExtension.class)
             .withPackage(DefaultBeanDiscoveryModeTest.class.getPackage()).build();

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/exclude/ExcludeFiltersTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/exclude/ExcludeFiltersTest.java
@@ -36,6 +36,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeanDiscoveryMode;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
@@ -55,21 +56,19 @@ public class ExcludeFiltersTest extends AbstractTest {
                 .withPackage(Beard.class.getPackage())
                 .withPackage(Chonmage.class.getPackage())
                 .withPackage(Meat.class.getPackage())
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).beanDiscoveryMode(BeanDiscoveryMode._ALL.toString()).createScan().createExclude()
-                                .name(Chonmage.class.getPackage().getName() + ".*").up().createExclude()
-                                .name(Mustache.class.getPackage().getName() + ".**").up().createExclude()
-                                .name(Meat.class.getPackage().getName() + ".*").createIfClassAvailable().name("com.some.unreal.class.Name").up().up().createExclude()
-                                .name(Meat.class.getPackage().getName() + ".*").createIfClassNotAvailable().name(ExcludeFiltersTest.class.getName()).up().up().createExclude()
-                                .name(Alpha.class.getName()).createIfClassAvailable().name(Stubble.class.getName()).up().up().createExclude()
-                                .name(Stubble.class.getName()).up().createExclude()
-                                .name(Foxtrot.class.getName()).createIfClassAvailable().name("com.some.unreal.class.Name").up().up().createExclude()
-                                .name(Bravo.class.getName()).createIfClassNotAvailable().name("com.some.unreal.class.Name").up().up().createExclude()
-                                .name(Echo.class.getName()).createIfClassNotAvailable().name(ExcludeFiltersTest.class.getName()).up().up().createExclude()
-                                .name(Charlie.class.getName()).createIfSystemProperty().name(TestSystemProperty.EXCLUDE_DUMMY.getKey()).up().up().createExclude()
-                                .name(Delta.class.getName()).createIfSystemProperty().name(TestSystemProperty.EXCLUDE_DUMMY.getKey())
-                                .value(TestSystemProperty.EXCLUDE_DUMMY.getValue()).up().up().up()
-                )
+                .withBeansXml(new BeansXml().excludeFilters(
+                        BeansXml.Exclude.match(Chonmage.class.getPackage().getName() + ".*"),
+                        BeansXml.Exclude.match(Mustache.class.getPackage().getName() + ".**"),
+                        BeansXml.Exclude.match(Meat.class.getPackage().getName() + ".*").ifClassAvailable("com.some.unreal.class.Name"),
+                        BeansXml.Exclude.match(Meat.class.getPackage().getName() + ".*").ifClassNotAvailable(ExcludeFiltersTest.class.getName()),
+                        BeansXml.Exclude.match(Alpha.class.getName()).ifClassAvailable(Stubble.class.getName()),
+                        BeansXml.Exclude.match(Stubble.class.getName()),
+                        BeansXml.Exclude.match(Foxtrot.class.getName()).ifClassAvailable("com.some.unreal.class.Name"),
+                        BeansXml.Exclude.match(Bravo.class.getName()).ifClassNotAvailable("com.some.unreal.class.Name"),
+                        BeansXml.Exclude.match(Echo.class.getName()).ifClassNotAvailable(ExcludeFiltersTest.class.getName()),
+                        BeansXml.Exclude.match(Charlie.class.getName()).ifSystemProperty(TestSystemProperty.EXCLUDE_DUMMY.getKey()),
+                        BeansXml.Exclude.match(Delta.class.getName()).ifSystemProperty(TestSystemProperty.EXCLUDE_DUMMY.getKey(), TestSystemProperty.EXCLUDE_DUMMY.getValue())
+                ))
                 .withExtension(VerifyingExtension.class).build();
     }
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/modules/EnterpriseArchiveModulesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/modules/EnterpriseArchiveModulesTest.java
@@ -30,31 +30,28 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
-import java.util.Set;
-
 import jakarta.enterprise.context.spi.CreationalContext;
 import jakarta.enterprise.inject.spi.Bean;
 import jakarta.enterprise.inject.spi.Extension;
 import jakarta.inject.Inject;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.EnterpriseArchiveBuilder;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
-import org.jboss.cdi.tck.util.Versions;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeanDiscoveryMode;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
 import org.jboss.shrinkwrap.descriptor.api.spec.se.manifest.ManifestDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
+
+import java.util.Set;
 
 /**
  * This test is aimed to verify packaging-related issues in a little bit more complex deployment scenario. The assertions are
@@ -105,10 +102,7 @@ public class EnterpriseArchiveModulesTest extends AbstractTest {
                 .create(JavaArchive.class, "bar-ejb.jar")
                 .addClasses(Bar.class, AlternativeBar.class, BarInspector.class, ContainerEventsObserver.class, LegacyServiceProducer.class)
                 .addAsServiceProvider(Extension.class, ContainerEventsObserver.class)
-                .addAsManifestResource(
-                        new StringAsset(Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors()
-                                .clazz(SecurityInterceptor.class.getName()).up().beanDiscoveryMode(BeanDiscoveryMode._ALL.toString()).version(Versions.v1_1)
-                                .exportAsString()), "beans.xml")
+                .addAsManifestResource(new BeansXml().interceptors(SecurityInterceptor.class), "beans.xml")
                 // Make A visible in a portable way
                 .setManifest(
                         new StringAsset(Descriptors.create(ManifestDescriptor.class)
@@ -120,9 +114,7 @@ public class EnterpriseArchiveModulesTest extends AbstractTest {
                 .notTestArchive()
                 // F - with enabled decorator
                 .withClasses(Baz.class, EnterpriseArchiveModulesTest.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateDecorators().clazz(LoggingDecorator.class.getName())
-                                .up().getOrCreateAlternatives().clazz(AlternativeBar.class.getName()).up())
+                .withBeansXml(new BeansXml().decorators(LoggingDecorator.class).alternatives(AlternativeBar.class))
                 // G
                 .withBeanLibrary(Qux.class)
                 .build()

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ejb/EJBJarDeploymentTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ejb/EJBJarDeploymentTest.java
@@ -37,6 +37,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeanDiscoveryMode;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -53,8 +54,7 @@ public class EJBJarDeploymentTest extends AbstractTest {
                 .create(JavaArchive.class, "test-ejb.jar")
                 .addClasses(FooRemote.class, FooBean.class, Bar.class, ProcessBeanObserver.class)
                 .addAsServiceProvider(Extension.class, ProcessBeanObserver.class)
-                .addAsManifestResource(new StringAsset(Descriptors.create(BeansDescriptor.class).beanDiscoveryMode(BeanDiscoveryMode._ALL.toString()).version(
-                        Versions.v1_1).exportAsString()), "beans.xml");
+                .addAsManifestResource(new BeansXml(), "beans.xml");
     }
 
     @Deployment(name = "TEST", order = 2)

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/rar/ResourceAdapterArchiveTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/rar/ResourceAdapterArchiveTest.java
@@ -25,16 +25,14 @@ import static org.testng.Assert.assertNotNull;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.EnterpriseArchiveBuilder;
-import org.jboss.cdi.tck.util.Versions;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeanDiscoveryMode;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
 import org.jboss.shrinkwrap.descriptor.api.connector16.ConnectorDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
@@ -59,9 +57,7 @@ public class ResourceAdapterArchiveTest extends AbstractTest {
         rar.addAsLibrary(ShrinkWrap
                 .create(JavaArchive.class)
                 .addClasses(Translator.class, TestResourceAdapter.class)
-                .addAsManifestResource(new StringAsset(Descriptors.create(BeansDescriptor.class)
-                        .beanDiscoveryMode(BeanDiscoveryMode._ALL.toString()).version(Versions.v1_1)
-                        .exportAsString()), "beans.xml"));
+                .addAsManifestResource(new BeansXml(), "beans.xml"));
         rar.addAsManifestResource(
                 new StringAsset(Descriptors.create(ConnectorDescriptor.class).version("1.6").displayName("Test RA")
                         .vendorName("Red Hat Middleware LLC").eisType("Test RA").resourceadapterVersion("0.1")

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/war/modules/WebArchiveModulesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/war/modules/WebArchiveModulesTest.java
@@ -30,22 +30,20 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
-import java.util.Set;
-
 import jakarta.enterprise.context.spi.CreationalContext;
 import jakarta.enterprise.inject.spi.Bean;
 import jakarta.inject.Inject;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
+
+import java.util.Set;
 
 /**
  * This test is aimed to verify packaging-related issues in a little bit more complex deployment scenario. The assertions are
@@ -74,18 +72,12 @@ public class WebArchiveModulesTest extends AbstractTest {
         return new WebArchiveBuilder().withTestClass(WebArchiveModulesTest.class)
                 // A
                 .withClasses(Foo.class, Secured.class, SecurityInterceptor.class, Business.class, BusinessOperationEvent.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateAlternatives().clazz(AlternativeBar.class.getName())
-                                .up())
+                .withBeansXml(new BeansXml().alternatives(AlternativeBar.class))
                 // B
-                .withBeanLibrary(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors()
-                                .clazz(SecurityInterceptor.class.getName()).up(), Bar.class, AlternativeBar.class,
+                .withBeanLibrary(new BeansXml().interceptors(SecurityInterceptor.class), Bar.class, AlternativeBar.class,
                         BarInspector.class)
                 // C
-                .withBeanLibrary(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateDecorators().clazz(LoggingDecorator.class.getName())
-                                .up(), Baz.class, LoggingDecorator.class, Bazinga.class)
+                .withBeanLibrary(new BeansXml().decorators(LoggingDecorator.class), Baz.class, LoggingDecorator.class, Bazinga.class)
                 // D
                 .withBeanLibrary(Qux.class, ContainerEventsObserver.class, LegacyServiceProducer.class)
                 // E

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/alternative/deployment/AlternativeInLibraryWithExtensionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/alternative/deployment/AlternativeInLibraryWithExtensionTest.java
@@ -21,13 +21,11 @@ import static org.jboss.cdi.tck.cdi.Sections.DECLARING_SELECTED_ALTERNATIVES_BEA
 import static org.jboss.cdi.tck.cdi.Sections.INITIALIZATION;
 
 import jakarta.inject.Inject;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
@@ -55,9 +53,8 @@ public class AlternativeInLibraryWithExtensionTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder()
                 .withTestClass(AlternativeInLibraryWithExtensionTest.class)
-                .withBeanLibrary(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateAlternatives().clazz(BarAlternative.class.getName())
-                                .up(), Foo.class, Bar.class, BarAlternative.class, NoopExtension.class).build();
+                .withBeanLibrary(new BeansXml().alternatives(BarAlternative.class),
+                        Foo.class, Bar.class, BarAlternative.class, NoopExtension.class).build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/alternative/metadata/AlternativeMetadataTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/alternative/metadata/AlternativeMetadataTest.java
@@ -23,25 +23,23 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
-import java.lang.annotation.Annotation;
-import java.util.Set;
-
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.enterprise.context.spi.CreationalContext;
 import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.spi.Bean;
 import jakarta.enterprise.util.AnnotationLiteral;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
+
+import java.lang.annotation.Annotation;
+import java.util.Set;
 
 /**
  * This test class contains tests for adding meta data using extensions.
@@ -57,10 +55,7 @@ public class AlternativeMetadataTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder()
                 .withTestClassPackage(AlternativeMetadataTest.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors()
-                                .clazz(GroceryInterceptor.class.getName()).up()
-                )
+                .withBeansXml(new BeansXml().interceptors(GroceryInterceptor.class))
                 .withExtension(ProcessAnnotatedTypeObserver.class).build();
     }
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/alternative/metadata/interceptor/AlternativeMetadataInterceptorInjectionTargetTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/alternative/metadata/interceptor/AlternativeMetadataInterceptorInjectionTargetTest.java
@@ -40,6 +40,7 @@ import org.jboss.cdi.tck.util.ForwardingAnnotatedType;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
@@ -52,7 +53,8 @@ public class AlternativeMetadataInterceptorInjectionTargetTest extends AbstractT
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder().withTestClass(AlternativeMetadataInterceptorInjectionTargetTest.class)
                 .withClasses(Login.class, LoginInterceptor.class, LoginInterceptorBinding.class, Secured.class)
-                .withBeansXml(Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors().clazz(LoginInterceptor.class.getName()).up()).build();
+                .withBeansXml(new BeansXml().interceptors(LoginInterceptor.class))
+                .build();
     }
 
     @Inject

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/alternative/metadata/interceptor/AlternativeMetadataInterceptorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/alternative/metadata/interceptor/AlternativeMetadataInterceptorTest.java
@@ -28,6 +28,7 @@ import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
@@ -46,7 +47,7 @@ public class AlternativeMetadataInterceptorTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder().withTestClass(AlternativeMetadataInterceptorTest.class)
                 .withClasses(InterceptorExtension.class, Login.class, LoginInterceptor.class, LoginInterceptorBinding.class, Secured.class)
-                .withBeansXml(Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors().clazz(LoginInterceptor.class.getName()).up())
+                .withBeansXml(new BeansXml().interceptors(LoginInterceptor.class))
                 .withExtension(InterceptorExtension.class).build();
     }
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/bean/bytype/BeanByTypeTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/bean/bytype/BeanByTypeTest.java
@@ -33,6 +33,7 @@ import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
@@ -51,9 +52,7 @@ public class BeanByTypeTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder()
                 .withTestClassPackage(BeanByTypeTest.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateAlternatives()
-                                .clazz(AlternativeConnector.class.getName()).up()).build();
+                .withBeansXml(new BeansXml().alternatives(AlternativeConnector.class)).build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/beanManager/BeanManagerTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/beanManager/BeanManagerTest.java
@@ -34,17 +34,6 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
-import java.lang.annotation.Annotation;
-import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Inherited;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
-
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.enterprise.context.SessionScoped;
@@ -58,19 +47,28 @@ import jakarta.enterprise.inject.spi.Bean;
 import jakarta.enterprise.inject.spi.InjectionPoint;
 import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.interceptor.InterceptorBinding;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.literals.RetentionLiteral;
 import org.jboss.cdi.tck.literals.TargetLiteral;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Mostly tests for extensions specified in chapter 11 of the specification and not already tested elsewhere.
@@ -88,7 +86,7 @@ public class BeanManagerTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder().withTestClassPackage(BeanManagerTest.class)
                 .withClasses(RetentionLiteral.class, TargetLiteral.class)
-                .withBeansXml(Descriptors.create(BeansDescriptor.class).getOrCreateAlternatives().clazz(Soy.class.getName()).up())
+                .withBeansXml(new BeansXml().alternatives(Soy.class))
                 .withExtensions(AfterBeanDiscoveryObserver.class).build();
     }
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/beanManager/bean/SyntheticBeanTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/beanManager/bean/SyntheticBeanTest.java
@@ -28,13 +28,11 @@ import jakarta.enterprise.inject.spi.Bean;
 import jakarta.enterprise.inject.spi.InjectionPoint;
 import jakarta.enterprise.inject.spi.PassivationCapable;
 import jakarta.inject.Inject;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
@@ -56,8 +54,7 @@ public class SyntheticBeanTest extends AbstractTest {
         return new WebArchiveBuilder()
                 .withTestClassPackage(SyntheticBeanTest.class)
                 .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors().clazz(SimpleInterceptor.class.getName())
-                                .up().getOrCreateDecorators().clazz(VehicleDecorator.class.getName()).up())
+                        new BeansXml().interceptors(SimpleInterceptor.class).decorators(VehicleDecorator.class))
                 .withExtension(BeanExtension.class).build();
     }
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/beanManager/equivalence/interceptorbinding/InterceptorBindingEquivalenceTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/beanManager/equivalence/interceptorbinding/InterceptorBindingEquivalenceTest.java
@@ -35,6 +35,7 @@ import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
@@ -51,9 +52,7 @@ public class InterceptorBindingEquivalenceTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder()
                 .withTestClassPackage(InterceptorBindingEquivalenceTest.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors()
-                                .clazz(MissileInterceptor.class.getName()).up()).build();
+                .withBeansXml(new BeansXml().interceptors(MissileInterceptor.class)).build();
     }
 
     @SuppressWarnings("serial")

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/configurators/beanAttributes/BeanAttributesConfiguratorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/configurators/beanAttributes/BeanAttributesConfiguratorTest.java
@@ -21,26 +21,25 @@ import static org.jboss.cdi.tck.cdi.Sections.PROCESS_BEAN_ATTRIBUTES;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanAttributes;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.cdi.tck.AbstractTest;
+import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.impl.BeansXml;
+import org.jboss.test.audit.annotations.SpecAssertion;
+import org.jboss.test.audit.annotations.SpecAssertions;
+import org.jboss.test.audit.annotations.SpecVersion;
+import org.testng.annotations.Test;
+
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
-import jakarta.enterprise.context.RequestScoped;
-import jakarta.enterprise.inject.Any;
-import jakarta.enterprise.inject.spi.Bean;
-import jakarta.enterprise.inject.spi.BeanAttributes;
-
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.cdi.tck.AbstractTest;
-import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
-import org.jboss.test.audit.annotations.SpecAssertion;
-import org.jboss.test.audit.annotations.SpecAssertions;
-import org.jboss.test.audit.annotations.SpecVersion;
-import org.testng.annotations.Test;
 
 /**
  * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
@@ -55,9 +54,7 @@ public class BeanAttributesConfiguratorTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder().withTestClassPackage(BeanAttributesConfiguratorTest.class)
                 .withExtension(ProcessBeanAttributesObserver.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateAlternatives()
-                                .clazz(Axe.class.getName()).up())
+                .withBeansXml(new BeansXml().alternatives(Axe.class))
                 .build();
     }
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/interceptors/InterceptorExtensionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/interceptors/InterceptorExtensionTest.java
@@ -26,13 +26,11 @@ import jakarta.enterprise.context.spi.CreationalContext;
 import jakarta.enterprise.inject.spi.Bean;
 import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.inject.Inject;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
@@ -61,8 +59,7 @@ public class InterceptorExtensionTest extends AbstractTest {
                 .withLibrary(SuffixingInterceptor.class, IncrementingInterceptor.class, LifecycleInterceptor.class, Suffixed.class, FullMarathon.class, Incremented.class,
                         InterceptorExtension.class)
                 .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors()
-                                .clazz(SuffixingInterceptor.class.getName(), IncrementingInterceptor.class.getName(), LifecycleInterceptor.class.getName()).up())
+                        new BeansXml().interceptors(SuffixingInterceptor.class, IncrementingInterceptor.class, LifecycleInterceptor.class))
                 .build();
     }
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/interceptors/custom/CustomInterceptorInvocationTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/interceptors/custom/CustomInterceptorInvocationTest.java
@@ -22,14 +22,12 @@ import static org.testng.Assert.assertTrue;
 
 import jakarta.inject.Inject;
 import jakarta.interceptor.Interceptor;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.cdi.tck.util.HierarchyDiscovery;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
@@ -62,9 +60,7 @@ public class CustomInterceptorInvocationTest extends AbstractTest {
                         CustomInterceptorExtension.class, FooInterceptor.class, FooInterceptorBinding.class,
                         InterceptedBean.class)
                 .withExtension(CustomInterceptorExtension.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors().clazz(FooInterceptor.class.getName())
-                                .up()).build();
+                .withBeansXml(new BeansXml().interceptors(FooInterceptor.class)).build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/interceptors/custom/CustomInterceptorRegistrationTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/interceptors/custom/CustomInterceptorRegistrationTest.java
@@ -19,14 +19,12 @@ package org.jboss.cdi.tck.tests.extensions.interceptors.custom;
 import static org.jboss.cdi.tck.cdi.Sections.AFTER_BEAN_DISCOVERY;
 
 import jakarta.interceptor.Interceptor;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.cdi.tck.util.HierarchyDiscovery;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
@@ -56,9 +54,7 @@ public class CustomInterceptorRegistrationTest extends AbstractTest {
                         CustomInterceptorExtension.class, FooInterceptor.class, FooInterceptorBinding.class,
                         InterceptedBean.class, InterceptedSerializableBean.class)
                 .withExtension(CustomInterceptorExtension.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors().clazz(FooInterceptor.class.getName())
-                                .up()).build();
+                .withBeansXml(new BeansXml().interceptors(FooInterceptor.class)).build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/atd/AfterTypeDiscoveryTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/atd/AfterTypeDiscoveryTest.java
@@ -27,7 +27,6 @@ import jakarta.enterprise.context.RequestScoped;
 import jakarta.enterprise.inject.spi.Bean;
 import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Inject;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
@@ -37,8 +36,7 @@ import org.jboss.cdi.tck.tests.extensions.lifecycle.atd.lib.Boss;
 import org.jboss.cdi.tck.tests.extensions.lifecycle.atd.lib.Foo;
 import org.jboss.cdi.tck.tests.extensions.lifecycle.atd.lib.Pro;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
@@ -56,11 +54,9 @@ public class AfterTypeDiscoveryTest extends AbstractTest {
                 .withTestClassPackage(AfterTypeDiscoveryTest.class)
                 .withExtension(AfterTypeDiscoveryObserver.class)
                 .withLibrary(Boss.class, Foo.class, Bar.class, Baz.class, Pro.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors()
-                                .clazz(CharlieInterceptor.class.getName()).up().getOrCreateDecorators()
-                                .clazz(CharlieDecorator.class.getName()).up().getOrCreateAlternatives()
-                                .clazz(CharlieAlternative.class.getName()).up()).build();
+                .withBeansXml(new BeansXml().interceptors(CharlieInterceptor.class)
+                        .decorators(CharlieDecorator.class).alternatives(CharlieAlternative.class))
+                .build();
     }
 
     @Inject

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processBeanAttributes/VerifyValuesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processBeanAttributes/VerifyValuesTest.java
@@ -26,8 +26,6 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
-import java.lang.annotation.Annotation;
-
 import jakarta.decorator.Decorator;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.Dependent;
@@ -42,17 +40,17 @@ import jakarta.enterprise.inject.spi.AnnotatedType;
 import jakarta.enterprise.inject.spi.BeanAttributes;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
+
+import java.lang.annotation.Annotation;
 
 /**
  * <p/>
@@ -74,10 +72,9 @@ public class VerifyValuesTest extends AbstractTest {
         return new WebArchiveBuilder()
                 .withTestClassPackage(VerifyValuesTest.class)
                 .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateAlternatives()
-                                .clazz(Alpha.class.getName(), BravoProducer.class.getName(), CharlieProducer.class.getName())
-                                .up().getOrCreateInterceptors().clazz(BravoInterceptor.class.getName()).up().getOrCreateDecorators()
-                                .clazz(BravoDecorator.class.getName()).up()).withExtension(VerifyingExtension.class).build();
+                        new BeansXml().alternatives(Alpha.class, BravoProducer.class, CharlieProducer.class)
+                            .interceptors(BravoInterceptor.class).decorators(BravoDecorator.class))
+                .withExtension(VerifyingExtension.class).build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processBeanAttributes/decorator/DecoratorProcessBeanAttributesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processBeanAttributes/decorator/DecoratorProcessBeanAttributesTest.java
@@ -24,8 +24,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -45,12 +44,9 @@ public class DecoratorProcessBeanAttributesTest extends AbstractTest {
                 .withClasses(VerifyingExtension.class, AlphaDecorator.class, Alpha.class, Charlie.class)
                 .withExtension(VerifyingExtension.class)
                 .withBeanLibrary(BravoDecorator.class, Bravo.class)
-                .withBeanLibrary(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateDecorators()
-                                .clazz(AlphaDecorator.class.getName(), BravoDecorator.class.getName()).up())
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateDecorators()
-                                .clazz(AlphaDecorator.class.getName(), BravoDecorator.class.getName()).up()).build();
+                .withBeanLibrary(new BeansXml().decorators(AlphaDecorator.class, BravoDecorator.class))
+                .withBeansXml(new BeansXml().decorators(AlphaDecorator.class, BravoDecorator.class))
+                .build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processBeanAttributes/interceptor/InterceptorProcessBeanAttributesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processBeanAttributes/interceptor/InterceptorProcessBeanAttributesTest.java
@@ -24,8 +24,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -45,12 +44,9 @@ public class InterceptorProcessBeanAttributesTest extends AbstractTest {
                 .withClasses(VerifyingExtension.class, AlphaInterceptor.class, AlphaInterceptorBinding.class)
                 .withExtension(VerifyingExtension.class)
                 .withBeanLibrary(BravoInterceptor.class, BravoInterceptorBinding.class)
-                .withBeanLibrary(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors()
-                                .clazz(AlphaInterceptor.class.getName(), BravoInterceptor.class.getName()).up())
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors()
-                                .clazz(AlphaInterceptor.class.getName(), BravoInterceptor.class.getName()).up()).build();
+                .withBeanLibrary(new BeansXml().interceptors(AlphaInterceptor.class, BravoInterceptor.class))
+                .withBeansXml(new BeansXml().interceptors(AlphaInterceptor.class, BravoInterceptor.class))
+                .build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processBeanAttributes/modify/SetBeanAttributesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processBeanAttributes/modify/SetBeanAttributesTest.java
@@ -33,6 +33,7 @@ import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
@@ -53,7 +54,7 @@ public class SetBeanAttributesTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder().withTestClassPackage(SetBeanAttributesTest.class)
                 .withExtension(ModifyingExtension.class)
-                .withBeansXml(Descriptors.create(BeansDescriptor.class).getOrCreateAlternatives().clazz(Cat.class.getName()).up())
+                .withBeansXml(new BeansXml().alternatives(Cat.class))
                 .build();
     }
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processInjectionPoint/modify/InjectionPointOverridingTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processInjectionPoint/modify/InjectionPointOverridingTest.java
@@ -32,6 +32,7 @@ import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
@@ -53,9 +54,8 @@ public class InjectionPointOverridingTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder()
                 .withTestClassPackage(InjectionPointOverridingTest.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateDecorators().clazz(AnimalDecorator.class.getName())
-                                .up()).withExtension(ModifyingExtension.class).build();
+                .withBeansXml(new BeansXml().decorators(AnimalDecorator.class))
+                .withExtension(ModifyingExtension.class).build();
     }
 
     @Inject

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/processBean/ProcessBeanTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/processBean/ProcessBeanTest.java
@@ -41,6 +41,7 @@ import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
@@ -59,10 +60,9 @@ public class ProcessBeanTest extends AbstractTest {
         return new WebArchiveBuilder()
                 .withTestClass(ProcessBeanTest.class)
                 .withClasses(Cat.class, Cow.class, Cowshed.class, Domestic.class, Chicken.class, ChickenHutch.class,
-                        ProcessBeanObserver.class, CatInterceptor.class, CatInterceptorBinding.class, Animal.class, AnimalDecorator.class).
-                        withBeansXml(Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors().clazz(CatInterceptor.class.getName())
-                                .up().getOrCreateDecorators().clazz(AnimalDecorator.class.getName()).up()).
-                        withExtension(ProcessBeanObserver.class).build();
+                        ProcessBeanObserver.class, CatInterceptor.class, CatInterceptorBinding.class, Animal.class, AnimalDecorator.class)
+                .withBeansXml(new BeansXml().interceptors(CatInterceptor.class).decorators(AnimalDecorator.class))
+                .withExtension(ProcessBeanObserver.class).build();
     }
 
     @SuppressWarnings("unchecked")

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/BuiltinMetadataBeanTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/BuiltinMetadataBeanTest.java
@@ -19,26 +19,24 @@ package org.jboss.cdi.tck.tests.implementation.builtin.metadata;
 import static org.jboss.cdi.tck.cdi.Sections.BEAN_METADATA;
 import static org.testng.Assert.assertEquals;
 
-import java.lang.reflect.Type;
-import java.util.Collections;
-
 import jakarta.enterprise.context.spi.CreationalContext;
 import jakarta.enterprise.inject.spi.Bean;
 import jakarta.enterprise.inject.spi.Decorator;
 import jakarta.enterprise.inject.spi.InterceptionType;
 import jakarta.enterprise.inject.spi.Interceptor;
 import jakarta.inject.Inject;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
+
+import java.lang.reflect.Type;
+import java.util.Collections;
 
 /**
  * <p>
@@ -58,10 +56,7 @@ public class BuiltinMetadataBeanTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder()
                 .withTestClassPackage(BuiltinMetadataBeanTest.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors()
-                                .clazz(YoghurtInterceptor.class.getName()).up().getOrCreateDecorators()
-                                .clazz(MilkProductDecorator.class.getName()).up()).build();
+                .withBeansXml(new BeansXml().interceptors(YoghurtInterceptor.class).decorators(MilkProductDecorator.class)).build();
     }
 
     @Inject

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/session/BuiltinMetadataSessionBeanTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/session/BuiltinMetadataSessionBeanTest.java
@@ -16,31 +16,29 @@
  */
 package org.jboss.cdi.tck.tests.implementation.builtin.metadata.session;
 
-import static org.jboss.cdi.tck.cdi.Sections.BEAN_METADATA;
 import static org.jboss.cdi.tck.TestGroups.JAVAEE_FULL;
+import static org.jboss.cdi.tck.cdi.Sections.BEAN_METADATA;
 import static org.testng.Assert.assertEquals;
-
-import java.lang.reflect.Type;
-import java.util.Collections;
 
 import jakarta.enterprise.inject.spi.Bean;
 import jakarta.enterprise.inject.spi.Decorator;
 import jakarta.enterprise.inject.spi.InterceptionType;
 import jakarta.enterprise.inject.spi.Interceptor;
 import jakarta.inject.Inject;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.cdi.tck.tests.implementation.builtin.metadata.Frozen;
 import org.jboss.cdi.tck.tests.implementation.builtin.metadata.YoghurtInterceptor;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
+
+import java.lang.reflect.Type;
+import java.util.Collections;
 
 /**
  * @author Tomas Remes
@@ -55,10 +53,7 @@ public class BuiltinMetadataSessionBeanTest extends AbstractTest {
                 .withTestClassPackage(BuiltinMetadataSessionBeanTest.class)
                 .withClasses(YoghurtInterceptor.class, Frozen.class)
                 .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors()
-                                .clazz(YoghurtInterceptor.class.getName()).up().getOrCreateDecorators()
-                                .clazz(BakeryProductDecorator.class.getName())
-                                .up()).build();
+                        new BeansXml().interceptors(YoghurtInterceptor.class).decorators(BakeryProductDecorator.class)).build();
     }
 
     @Inject

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/decorator/DisposerMethodOnDecoratorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/decorator/DisposerMethodOnDecoratorTest.java
@@ -19,14 +19,12 @@ package org.jboss.cdi.tck.tests.implementation.disposal.method.definition.broken
 import static org.jboss.cdi.tck.cdi.Sections.DECLARING_DISPOSER_METHOD;
 
 import jakarta.enterprise.inject.spi.DefinitionException;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -39,9 +37,7 @@ public class DisposerMethodOnDecoratorTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder()
                 .withTestClassPackage(DisposerMethodOnDecoratorTest.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateDecorators().clazz(FooDecorator_Broken.class.getName())
-                                .up()).build();
+                .withBeansXml(new BeansXml().decorators(FooDecorator_Broken.class)).build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/interceptor/DisposerMethodOnInterceptorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/interceptor/DisposerMethodOnInterceptorTest.java
@@ -27,6 +27,7 @@ import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -39,9 +40,7 @@ public class DisposerMethodOnInterceptorTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder()
                 .withTestClassPackage(DisposerMethodOnInterceptorTest.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors()
-                                .clazz(SimpleInterceptor_Broken.class.getName()).up()).build();
+                .withBeansXml(new BeansXml().interceptors(SimpleInterceptor_Broken.class)).build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/newBean/NewEnterpriseBeanTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/newBean/NewEnterpriseBeanTest.java
@@ -23,9 +23,6 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
-import java.lang.reflect.Type;
-import java.util.Set;
-
 import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.enterprise.context.spi.CreationalContext;
@@ -33,17 +30,18 @@ import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Default;
 import jakarta.enterprise.inject.New;
 import jakarta.enterprise.inject.spi.Bean;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
+
+import java.lang.reflect.Type;
+import java.util.Set;
 
 @Test(groups = INTEGRATION)
 @SpecVersion(spec = "cdi", version = "2.0")
@@ -57,9 +55,7 @@ public class NewEnterpriseBeanTest extends AbstractTest {
                         Dragon.class.getName(), NewEnterpriseBeanICTest.class.getName(), Hat.class.getName(),
                         Fireball.class.getName())
                 .withLibrary(Tiger.class, Spell.class, Staff.class, Dragon.class, Hat.class, Fireball.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors().clazz(OrderInterceptor.class.getName())
-                                .up()).build();
+                .withBeansXml(new BeansXml().interceptors(OrderInterceptor.class)).build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/decorator/ProducerFieldOnDecoratorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/decorator/ProducerFieldOnDecoratorTest.java
@@ -27,6 +27,7 @@ import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -39,9 +40,7 @@ public class ProducerFieldOnDecoratorTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder()
                 .withTestClassPackage(ProducerFieldOnDecoratorTest.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateDecorators().clazz(FooDecorator_Broken.class.getName())
-                                .up()).build();
+                .withBeansXml(new BeansXml().decorators(FooDecorator_Broken.class)).build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/interceptor/ProducerFieldOnInterceptorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/interceptor/ProducerFieldOnInterceptorTest.java
@@ -19,14 +19,12 @@ package org.jboss.cdi.tck.tests.implementation.producer.field.definition.broken.
 import static org.jboss.cdi.tck.cdi.Sections.DECLARING_PRODUCER_FIELD;
 
 import jakarta.enterprise.inject.spi.DefinitionException;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -39,9 +37,7 @@ public class ProducerFieldOnInterceptorTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder()
                 .withTestClassPackage(ProducerFieldOnInterceptorTest.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors()
-                                .clazz(SimpleInterceptor_Broken.class.getName()).up()).build();
+                .withBeansXml(new BeansXml().interceptors(SimpleInterceptor_Broken.class)).build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/decorator/ProducerMethodOnDecoratorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/decorator/ProducerMethodOnDecoratorTest.java
@@ -19,14 +19,12 @@ package org.jboss.cdi.tck.tests.implementation.producer.method.broken.decorator;
 import static org.jboss.cdi.tck.cdi.Sections.DECLARING_PRODUCER_METHOD;
 
 import jakarta.enterprise.inject.spi.DefinitionException;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -39,9 +37,7 @@ public class ProducerMethodOnDecoratorTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder()
                 .withTestClassPackage(ProducerMethodOnDecoratorTest.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateDecorators().clazz(FooDecorator_Broken.class.getName())
-                                .up()).build();
+                .withBeansXml(new BeansXml().decorators(FooDecorator_Broken.class)).build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/interceptor/ProducerMethodOnInterceptorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/interceptor/ProducerMethodOnInterceptorTest.java
@@ -19,14 +19,12 @@ package org.jboss.cdi.tck.tests.implementation.producer.method.broken.intercepto
 import static org.jboss.cdi.tck.cdi.Sections.DECLARING_PRODUCER_METHOD;
 
 import jakarta.enterprise.inject.spi.DefinitionException;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -39,9 +37,7 @@ public class ProducerMethodOnInterceptorTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder()
                 .withTestClassPackage(ProducerMethodOnInterceptorTest.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors()
-                                .clazz(SimpleInterceptor_Broken.class.getName()).up()).build();
+                .withBeansXml(new BeansXml().interceptors(SimpleInterceptor_Broken.class)).build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/newSimpleBean/NewSimpleBeanTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/newSimpleBean/NewSimpleBeanTest.java
@@ -17,10 +17,28 @@
 package org.jboss.cdi.tck.tests.implementation.simple.newSimpleBean;
 
 import static org.jboss.cdi.tck.cdi.Sections.NEW;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.Default;
+import jakarta.enterprise.inject.New;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.util.TypeLiteral;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.cdi.tck.AbstractTest;
+import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
+import org.jboss.cdi.tck.util.DependentInstance;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.impl.BeansXml;
+import org.jboss.test.audit.annotations.SpecAssertion;
+import org.jboss.test.audit.annotations.SpecAssertions;
+import org.jboss.test.audit.annotations.SpecVersion;
+import org.testng.annotations.Test;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -30,26 +48,6 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.TreeSet;
 
-import jakarta.enterprise.context.RequestScoped;
-import jakarta.enterprise.context.spi.CreationalContext;
-import jakarta.enterprise.inject.Any;
-import jakarta.enterprise.inject.Default;
-import jakarta.enterprise.inject.New;
-import jakarta.enterprise.inject.spi.Bean;
-import jakarta.enterprise.util.TypeLiteral;
-
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.cdi.tck.AbstractTest;
-import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
-import org.jboss.cdi.tck.util.DependentInstance;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
-import org.jboss.test.audit.annotations.SpecAssertion;
-import org.jboss.test.audit.annotations.SpecAssertions;
-import org.jboss.test.audit.annotations.SpecVersion;
-import org.testng.annotations.Test;
-
 @SpecVersion(spec = "cdi", version = "2.0")
 public class NewSimpleBeanTest extends AbstractTest {
 
@@ -57,9 +55,7 @@ public class NewSimpleBeanTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder()
                 .withTestClassPackage(NewSimpleBeanTest.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateAlternatives().clazz(Tiger.class.getName()).up()
-                                .getOrCreateInterceptors().clazz(OrderInterceptor.class.getName()).up()).build();
+                .withBeansXml(new BeansXml().alternatives(Tiger.class).interceptors(OrderInterceptor.class)).build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/InterceptorDefinitionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/InterceptorDefinitionTest.java
@@ -27,6 +27,21 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
+import jakarta.enterprise.inject.spi.InterceptionType;
+import jakarta.enterprise.inject.spi.Interceptor;
+import jakarta.enterprise.util.AnnotationLiteral;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.cdi.tck.AbstractTest;
+import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
+import org.jboss.cdi.tck.util.HierarchyDiscovery;
+import org.jboss.cdi.tck.util.ParameterizedTypeImpl;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.impl.BeansXml;
+import org.jboss.test.audit.annotations.SpecAssertion;
+import org.jboss.test.audit.annotations.SpecAssertions;
+import org.jboss.test.audit.annotations.SpecVersion;
+import org.testng.annotations.Test;
+
 import java.lang.annotation.Annotation;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
@@ -36,23 +51,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
-import jakarta.enterprise.inject.spi.InterceptionType;
-import jakarta.enterprise.inject.spi.Interceptor;
-import jakarta.enterprise.util.AnnotationLiteral;
-
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.cdi.tck.AbstractTest;
-import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
-import org.jboss.cdi.tck.util.HierarchyDiscovery;
-import org.jboss.cdi.tck.util.ParameterizedTypeImpl;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
-import org.jboss.test.audit.annotations.SpecAssertion;
-import org.jboss.test.audit.annotations.SpecAssertions;
-import org.jboss.test.audit.annotations.SpecVersion;
-import org.testng.annotations.Test;
 
 /**
  * Tests related to the definition of interceptors, but not necessarily their execution.
@@ -84,13 +82,9 @@ public class InterceptorDefinitionTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder()
                 .withTestClassPackage(InterceptorDefinitionTest.class)
-                .withBeansXml(
-                        Descriptors
-                                .create(BeansDescriptor.class)
-                                .getOrCreateInterceptors()
-                                .clazz(AtomicInterceptor.class.getName(), MissileInterceptor.class.getName(),
-                                        SecureInterceptor.class.getName(), TransactionalInterceptor.class.getName(),
-                                        FileLogger.class.getName(), NetworkLogger.class.getName()).up()).build();
+                .withBeansXml(new BeansXml().interceptors(AtomicInterceptor.class, MissileInterceptor.class,
+                        SecureInterceptor.class, TransactionalInterceptor.class, FileLogger.class, NetworkLogger.class))
+                .build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/DependentBeanFinalMethodInterceptorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/DependentBeanFinalMethodInterceptorTest.java
@@ -19,14 +19,12 @@ package org.jboss.cdi.tck.tests.interceptors.definition.broken.finalClassInterce
 import static org.jboss.cdi.tck.cdi.Sections.BINDING_INTERCEPTOR_TO_BEAN;
 
 import jakarta.enterprise.inject.spi.DeploymentException;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -40,9 +38,7 @@ public class DependentBeanFinalMethodInterceptorTest extends AbstractTest {
         return new WebArchiveBuilder()
                 .withTestClassDefinition(DependentBeanFinalMethodInterceptorTest.class)
                 .withClasses(FooBinding.class, MissileInterceptor.class, NuclearMissileFinalMethod.class, NuclearMissileIPBean.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors()
-                                .clazz(MissileInterceptor.class.getName()).up()).build();
+                .withBeansXml(new BeansXml().interceptors(MissileInterceptor.class)).build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/FinalClassClassLevelInterceptorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/FinalClassClassLevelInterceptorTest.java
@@ -27,6 +27,7 @@ import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -45,9 +46,7 @@ public class FinalClassClassLevelInterceptorTest extends AbstractTest {
         return new WebArchiveBuilder()
                 .withTestClassDefinition(FinalClassClassLevelInterceptorTest.class)
                 .withClasses(FooBinding.class, MissileInterceptor.class, FinalClassClassLevelMissile.class, FinalClassClassLevelIPBean.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors()
-                                .clazz(MissileInterceptor.class.getName()).up()).build();
+                .withBeansXml(new BeansXml().interceptors(MissileInterceptor.class)).build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/FinalClassMethodLevelInterceptorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/FinalClassMethodLevelInterceptorTest.java
@@ -19,14 +19,12 @@ package org.jboss.cdi.tck.tests.interceptors.definition.broken.finalClassInterce
 import static org.jboss.cdi.tck.cdi.Sections.BINDING_INTERCEPTOR_TO_BEAN;
 
 import jakarta.enterprise.inject.spi.DeploymentException;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -45,9 +43,7 @@ public class FinalClassMethodLevelInterceptorTest extends AbstractTest {
         return new WebArchiveBuilder()
                 .withTestClassDefinition(FinalClassMethodLevelInterceptorTest.class)
                 .withClasses(FooBinding.class, MissileInterceptor.class, FinalClassMethodLevelMissile.class, FinalClassMethodLevelIPBean.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors()
-                                .clazz(MissileInterceptor.class.getName()).up()).build();
+                .withBeansXml(new BeansXml().interceptors(MissileInterceptor.class)).build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/FinalMethodClassLevelInterceptorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/FinalMethodClassLevelInterceptorTest.java
@@ -28,6 +28,7 @@ import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -47,9 +48,7 @@ public class FinalMethodClassLevelInterceptorTest extends AbstractTest {
                 .withTestClassDefinition(FinalMethodClassLevelInterceptorTest.class)
                 .withClasses(FooBinding.class, MissileInterceptor.class, FinalMethodClassLevelMissile.class,
                         FinalMethodClassLevelMissileLocal.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors()
-                                .clazz(MissileInterceptor.class.getName()).up()).build();
+                .withBeansXml(new BeansXml().interceptors(MissileInterceptor.class)).build();
     }
 
     //TODO disable due to https://issues.jboss.org/browse/CDI-496

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/FinalMethodMethodLevelInterceptorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/FinalMethodMethodLevelInterceptorTest.java
@@ -28,6 +28,7 @@ import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -47,9 +48,7 @@ public class FinalMethodMethodLevelInterceptorTest extends AbstractTest {
                 .withTestClassDefinition(FinalMethodMethodLevelInterceptorTest.class)
                 .withClasses(FooBinding.class, MissileInterceptor.class, FinalMethodMethodLevelMissile.class,
                         FinalMethodMethodLevelMissileLocal.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors()
-                                .clazz(MissileInterceptor.class.getName()).up()).build();
+                .withBeansXml(new BeansXml().interceptors(MissileInterceptor.class)).build();
     }
 
     //TODO disable due to https://issues.jboss.org/browse/CDI-496

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/NormalScopedBeanFinalClassInterceptorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/NormalScopedBeanFinalClassInterceptorTest.java
@@ -19,14 +19,12 @@ package org.jboss.cdi.tck.tests.interceptors.definition.broken.finalClassInterce
 import static org.jboss.cdi.tck.cdi.Sections.BINDING_INTERCEPTOR_TO_BEAN;
 
 import jakarta.enterprise.inject.spi.DeploymentException;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -40,9 +38,7 @@ public class NormalScopedBeanFinalClassInterceptorTest extends AbstractTest {
         return new WebArchiveBuilder()
                 .withTestClassDefinition(NormalScopedBeanFinalClassInterceptorTest.class)
                 .withClasses(FooBinding.class, MissileInterceptor.class, AntiAircraftMissileFinalClass.class, AntiAircraftIPBean.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors()
-                                .clazz(MissileInterceptor.class.getName()).up()).build();
+                .withBeansXml(new BeansXml().interceptors(MissileInterceptor.class)).build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/NormalScopedBeanFinalMethodInterceptorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/NormalScopedBeanFinalMethodInterceptorTest.java
@@ -19,14 +19,12 @@ package org.jboss.cdi.tck.tests.interceptors.definition.broken.finalClassInterce
 import static org.jboss.cdi.tck.cdi.Sections.BINDING_INTERCEPTOR_TO_BEAN;
 
 import jakarta.enterprise.inject.spi.DeploymentException;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -40,9 +38,7 @@ public class NormalScopedBeanFinalMethodInterceptorTest extends AbstractTest {
         return new WebArchiveBuilder()
                 .withTestClassDefinition(NormalScopedBeanFinalMethodInterceptorTest.class)
                 .withClasses(FooBinding.class, MissileInterceptor.class, SurfaceToAirMissileFinalMethod.class, SurfaceToAirIPBean.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors()
-                                .clazz(MissileInterceptor.class.getName()).up()).build();
+                .withBeansXml(new BeansXml().interceptors(MissileInterceptor.class)).build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/nonExistantClassInBeansXml/NonExistantClassInBeansXmlTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/nonExistantClassInBeansXml/NonExistantClassInBeansXmlTest.java
@@ -19,14 +19,11 @@ package org.jboss.cdi.tck.tests.interceptors.definition.broken.nonExistantClassI
 import static org.jboss.cdi.tck.cdi.Sections.ENABLED_INTERCEPTORS;
 
 import jakarta.enterprise.inject.spi.DeploymentException;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -38,7 +35,7 @@ public class NonExistantClassInBeansXmlTest extends AbstractTest {
     @Deployment
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder().withTestClassPackage(NonExistantClassInBeansXmlTest.class)
-                .withBeansXml(Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors().clazz("com.acme.Foo").up())
+                .withBeansXml("beans.xml")
                 .build();
     }
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/nonInterceptorClassInBeansXml/NonInterceptorClassInBeansXmlTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/nonInterceptorClassInBeansXml/NonInterceptorClassInBeansXmlTest.java
@@ -27,6 +27,7 @@ import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -38,7 +39,7 @@ public class NonInterceptorClassInBeansXmlTest extends AbstractTest {
     @Deployment
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder().withTestClassPackage(NonInterceptorClassInBeansXmlTest.class)
-                .withBeansXml(Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors().clazz(Foo.class.getName()).up())
+                .withBeansXml(new BeansXml().interceptors(Foo.class))
                 .build();
     }
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/observer/InterceptorWithObserverMethodTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/observer/InterceptorWithObserverMethodTest.java
@@ -19,14 +19,12 @@ package org.jboss.cdi.tck.tests.interceptors.definition.broken.observer;
 import static org.jboss.cdi.tck.cdi.Sections.OBSERVES;
 
 import jakarta.enterprise.inject.spi.DefinitionException;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -44,9 +42,7 @@ public class InterceptorWithObserverMethodTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder()
                 .withTestClassPackage(InterceptorWithObserverMethodTest.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors()
-                                .clazz(TransactionalInterceptor.class.getName()).up()).build();
+                .withBeansXml(new BeansXml().interceptors(TransactionalInterceptor.class)).build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/sameClassListedTwiceInBeansXml/SameClassListedTwiceInBeansXmlTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/sameClassListedTwiceInBeansXml/SameClassListedTwiceInBeansXmlTest.java
@@ -19,14 +19,12 @@ package org.jboss.cdi.tck.tests.interceptors.definition.broken.sameClassListedTw
 import static org.jboss.cdi.tck.cdi.Sections.ENABLED_INTERCEPTORS;
 
 import jakarta.enterprise.inject.spi.DeploymentException;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -40,8 +38,8 @@ public class SameClassListedTwiceInBeansXmlTest extends AbstractTest {
         return new WebArchiveBuilder()
                 .withTestClassPackage(SameClassListedTwiceInBeansXmlTest.class)
                 .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors()
-                                .clazz(FordInterceptor.class.getName(), FordInterceptor.class.getName()).up()).build();
+                        new BeansXml().interceptors(FordInterceptor.class, FordInterceptor.class))
+                .build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/conflictingenablement/InterceptorConflictingEnablementTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/conflictingenablement/InterceptorConflictingEnablementTest.java
@@ -21,18 +21,17 @@ import static org.jboss.cdi.tck.cdi.Sections.ENABLED_DECORATORS;
 import static org.jboss.cdi.tck.cdi.Sections.ENABLED_INTERCEPTORS;
 import static org.testng.Assert.assertEquals;
 
-import java.util.List;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.cdi.tck.util.ActionSequence;
 import org.jboss.shrinkwrap.api.Archive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
+
+import java.util.List;
 
 /**
  * This test was originally part of Weld testsuite
@@ -47,9 +46,10 @@ public class InterceptorConflictingEnablementTest extends AbstractTest {
     @Deployment
     public static Archive<?> createTestArchive() {
         return new WebArchiveBuilder().withTestClassPackage(InterceptorConflictingEnablementTest.class)
-                .withBeansXml(Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors()
-                        .clazz(TransactionalInterceptor.class.getName(), LoggingInterceptor.class.getName()).up().getOrCreateDecorators()
-                        .clazz(TestDecorator.class.getName(), AnotherTestDecorator.class.getName()).up()).build();
+                .withBeansXml(new BeansXml()
+                        .interceptors(TransactionalInterceptor.class, LoggingInterceptor.class)
+                        .decorators(TestDecorator.class, AnotherTestDecorator.class))
+                .build();
     }
 
     @org.testng.annotations.Test(dataProvider = ARQUILLIAN_DATA_PROVIDER)

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/jms/MessageDrivenBeanInterceptorInvocationTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/jms/MessageDrivenBeanInterceptorInvocationTest.java
@@ -23,23 +23,21 @@ import static org.jboss.cdi.tck.shrinkwrap.descriptors.ejb.EjbJarDescriptorBuild
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
-import java.util.concurrent.TimeUnit;
-
 import jakarta.inject.Inject;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.impl.ConfigurationFactory;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.cdi.tck.shrinkwrap.descriptors.ejb.EjbJarDescriptorBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
 import org.jboss.shrinkwrap.descriptor.api.ejbjar31.EjbJarDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
+
+import java.util.concurrent.TimeUnit;
 
 /**
  * Test that invocations of message listener methods of message-driven beans during message delivery are business method
@@ -64,9 +62,7 @@ public class MessageDrivenBeanInterceptorInvocationTest extends AbstractTest {
         return new WebArchiveBuilder()
                 .withTestClassPackage(MessageDrivenBeanInterceptorInvocationTest.class)
                 .withEjbJarXml(ejbJarDescriptor)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors()
-                                .clazz(MissileInterceptor.class.getName()).up()).build();
+                .withBeansXml(new BeansXml().interceptors(MissileInterceptor.class)).build();
     }
 
     @Inject

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/simpleInterception/SessionBeanInterceptorDefinitionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/simpleInterception/SessionBeanInterceptorDefinitionTest.java
@@ -23,13 +23,11 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 import jakarta.inject.Inject;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
@@ -42,9 +40,7 @@ public class SessionBeanInterceptorDefinitionTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder()
                 .withTestClassPackage(SessionBeanInterceptorDefinitionTest.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors()
-                                .clazz(MissileInterceptor.class.getName()).up()).build();
+                .withBeansXml(new BeansXml().interceptors(MissileInterceptor.class)).build();
     }
 
     @Inject

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/InterceptorBindingInheritanceTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/InterceptorBindingInheritanceTest.java
@@ -28,8 +28,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
@@ -48,8 +47,7 @@ public class InterceptorBindingInheritanceTest extends AbstractTest {
         return new WebArchiveBuilder()
                 .withTestClassPackage(InterceptorBindingInheritanceTest.class)
                 .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors()
-                                .clazz(SquirrelInterceptor.class.getName(), WoodpeckerInterceptor.class.getName()).up())
+                        new BeansXml().interceptors(SquirrelInterceptor.class, WoodpeckerInterceptor.class))
                 .build();
     }
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/broken/binding/FinalClassWithInheritedClassLevelInterceptorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/broken/binding/FinalClassWithInheritedClassLevelInterceptorTest.java
@@ -27,6 +27,7 @@ import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -45,8 +46,8 @@ public class FinalClassWithInheritedClassLevelInterceptorTest extends AbstractTe
                 .withTestClassDefinition(FinalClassWithInheritedClassLevelInterceptorTest.class)
                 .withClasses(Jumbojet.class, Airbus.class, LandingBinding.class, LandingInterceptor.class)
                 .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors()
-                                .clazz(LandingInterceptor.class.getName()).up()).build();
+                        new BeansXml().interceptors(LandingInterceptor.class))
+                .build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/broken/binding/FinalClassWithInheritedStereotypeInterceptorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/broken/binding/FinalClassWithInheritedStereotypeInterceptorTest.java
@@ -27,6 +27,7 @@ import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -46,8 +47,8 @@ public class FinalClassWithInheritedStereotypeInterceptorTest extends AbstractTe
                 .withClasses(Fighter.class, FighterStereotype.class, Messerschmitt.class, LandingBinding.class,
                         LandingInterceptor.class)
                 .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors()
-                                .clazz(LandingInterceptor.class.getName()).up()).build();
+                        new BeansXml().interceptors(LandingInterceptor.class))
+                .build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/broken/binding/FinalMethodWithInheritedClassLevelInterceptorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/broken/binding/FinalMethodWithInheritedClassLevelInterceptorTest.java
@@ -27,6 +27,7 @@ import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -45,8 +46,8 @@ public class FinalMethodWithInheritedClassLevelInterceptorTest extends AbstractT
                 .withTestClassDefinition(FinalMethodWithInheritedClassLevelInterceptorTest.class)
                 .withClasses(Jumbojet.class, Boeing.class, LandingBinding.class, LandingInterceptor.class)
                 .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors()
-                                .clazz(LandingInterceptor.class.getName()).up()).build();
+                        new BeansXml().interceptors(LandingInterceptor.class))
+                .build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/broken/binding/FinalMethodWithInheritedStereotypeInterceptorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/broken/binding/FinalMethodWithInheritedStereotypeInterceptorTest.java
@@ -27,6 +27,7 @@ import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -46,8 +47,8 @@ public class FinalMethodWithInheritedStereotypeInterceptorTest extends AbstractT
                 .withClasses(Fighter.class, FighterStereotype.class, Spitfire.class, LandingBinding.class,
                         LandingInterceptor.class)
                 .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors()
-                                .clazz(LandingInterceptor.class.getName()).up()).build();
+                        new BeansXml().interceptors(LandingInterceptor.class))
+                .build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/interceptorOrder/InterceptorOrderTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/interceptorOrder/InterceptorOrderTest.java
@@ -20,19 +20,18 @@ import static org.jboss.cdi.tck.cdi.Sections.ENABLED_INTERCEPTORS;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
-import java.util.List;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.cdi.tck.util.ActionSequence;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
+
+import java.util.List;
 
 @SpecVersion(spec = "cdi", version = "2.0")
 public class InterceptorOrderTest extends AbstractTest {
@@ -41,12 +40,8 @@ public class InterceptorOrderTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder()
                 .withTestClassPackage(InterceptorOrderTest.class)
-                .withBeansXml(
-                        Descriptors
-                                .create(BeansDescriptor.class)
-                                .getOrCreateInterceptors()
-                                .clazz(SecondInterceptor.class.getName(), FirstInterceptor.class.getName(),
-                                        TransactionalInterceptor.class.getName()).up()).build();
+                .withBeansXml(new BeansXml().interceptors(SecondInterceptor.class, FirstInterceptor.class, TransactionalInterceptor.class))
+                .build();
     }
 
     @Test(dataProvider = ARQUILLIAN_DATA_PROVIDER)

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/lifecycle/enterprise/order/EnterpriseLifecycleInterceptorDefinitionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/lifecycle/enterprise/order/EnterpriseLifecycleInterceptorDefinitionTest.java
@@ -20,22 +20,20 @@ import static org.jboss.cdi.tck.TestGroups.INTEGRATION;
 import static org.jboss.cdi.tck.cdi.Sections.ENABLED_INTERCEPTORS;
 import static org.testng.Assert.assertEquals;
 
-import java.util.List;
-
 import jakarta.enterprise.context.spi.CreationalContext;
 import jakarta.enterprise.inject.spi.Bean;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.cdi.tck.util.ActionSequence;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
+
+import java.util.List;
 
 @SpecVersion(spec = "cdi", version = "2.0")
 public class EnterpriseLifecycleInterceptorDefinitionTest extends AbstractTest {
@@ -45,8 +43,8 @@ public class EnterpriseLifecycleInterceptorDefinitionTest extends AbstractTest {
         return new WebArchiveBuilder()
                 .withTestClassPackage(EnterpriseLifecycleInterceptorDefinitionTest.class)
                 .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors()
-                                .clazz(MissileInterceptor.class.getName()).up()).build();
+                        new BeansXml().interceptors(MissileInterceptor.class))
+                .build();
     }
 
     @Test(groups = INTEGRATION)

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/lifecycle/order/LifecycleInterceptorOrderTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/lifecycle/order/LifecycleInterceptorOrderTest.java
@@ -19,22 +19,20 @@ package org.jboss.cdi.tck.tests.interceptors.definition.lifecycle.order;
 import static org.jboss.cdi.tck.cdi.Sections.ENABLED_INTERCEPTORS;
 import static org.testng.Assert.assertEquals;
 
-import java.util.List;
-
 import jakarta.enterprise.context.spi.CreationalContext;
 import jakarta.enterprise.inject.spi.Bean;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.cdi.tck.util.ActionSequence;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
+
+import java.util.List;
 
 @SpecVersion(spec = "cdi", version = "2.0")
 public class LifecycleInterceptorOrderTest extends AbstractTest {
@@ -44,8 +42,8 @@ public class LifecycleInterceptorOrderTest extends AbstractTest {
         return new WebArchiveBuilder()
                 .withTestClassPackage(LifecycleInterceptorOrderTest.class)
                 .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors()
-                                .clazz(TransactionalInterceptor.class.getName()).up()).build();
+                        new BeansXml().interceptors(TransactionalInterceptor.class))
+                .build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/member/InterceptorBindingTypeWithMemberTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/member/InterceptorBindingTypeWithMemberTest.java
@@ -26,8 +26,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -45,12 +44,7 @@ public class InterceptorBindingTypeWithMemberTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder()
                 .withTestClassPackage(InterceptorBindingTypeWithMemberTest.class)
-                .withBeansXml(
-                        Descriptors
-                                .create(BeansDescriptor.class)
-                                .getOrCreateInterceptors()
-                                .clazz(IncreasingInterceptor.class.getName(), DecreasingInterceptor.class.getName(),
-                                        VehicleCountInterceptor.class.getName()).up())
+                .withBeansXml(new BeansXml().interceptors(IncreasingInterceptor.class, DecreasingInterceptor.class, VehicleCountInterceptor.class))
                 .build();
     }
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/invocation/InterceptorInvocationTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/invocation/InterceptorInvocationTest.java
@@ -36,6 +36,7 @@ import org.jboss.cdi.tck.util.Timer.StopCondition;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
@@ -52,9 +53,7 @@ public class InterceptorInvocationTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder()
                 .withTestClassPackage(InterceptorInvocationTest.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors()
-                                .clazz(AlmightyInterceptor.class.getName()).up()).build();
+                .withBeansXml(new BeansXml().interceptors(AlmightyInterceptor.class)).build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/ordering/global/EnterpriseInterceptorOrderingTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/ordering/global/EnterpriseInterceptorOrderingTest.java
@@ -37,6 +37,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
 import org.jboss.shrinkwrap.descriptor.api.spec.se.manifest.ManifestDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
@@ -74,8 +75,7 @@ public class EnterpriseInterceptorOrderingTest extends AbstractTest {
                 //A - default test-ejb.jar
                 .withTestClassDefinition(EnterpriseInterceptorOrderingTest.class)
                 .withClasses(Dao.class, LegacyInterceptor2.class)
-                .withBeansXml(Descriptors.create(BeansDescriptor.class)
-                        .getOrCreateInterceptors().clazz(LegacyInterceptor2.class.getName()).up())
+                .withBeansXml(new BeansXml().interceptors(LegacyInterceptor2.class))
                 //B
                 .withBeanLibrary(Transactional.class, GloballyEnabledInterceptor3.class)
                 //C
@@ -86,9 +86,7 @@ public class EnterpriseInterceptorOrderingTest extends AbstractTest {
         JavaArchive ejbArchive = ShrinkWrap
                 .create(JavaArchive.class, ejbJar)
                 .addClasses(DummyDao.class, GloballyEnabledInterceptor2.class, GloballyEnabledInterceptor5.class, LegacyInterceptor3.class)
-                .addAsManifestResource(
-                        new StringAsset(Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors()
-                                .clazz(LegacyInterceptor3.class.getName()).up().exportAsString()), "beans.xml")
+                .addAsManifestResource(new BeansXml().interceptors(LegacyInterceptor3.class), "beans.xml")
                 .setManifest(
                         new StringAsset(Descriptors.create(ManifestDescriptor.class)
                                 .addToClassPath(EnterpriseArchiveBuilder.DEFAULT_EJB_MODULE_NAME)
@@ -100,8 +98,7 @@ public class EnterpriseInterceptorOrderingTest extends AbstractTest {
                 .notTestArchive()
                 //F
                 .withClasses(EnterpriseInterceptorOrderingTest.class, GloballyEnabledInterceptor1.class, LegacyInterceptor1.class)
-                .withBeansXml(Descriptors.create(BeansDescriptor.class)
-                        .getOrCreateInterceptors().clazz(LegacyInterceptor1.class.getName()).up())
+                .withBeansXml(new BeansXml().interceptors(LegacyInterceptor1.class))
                 //G
                 .withBeanLibrary(GloballyEnabledInterceptor4.class)
                 .build()

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/ordering/global/GlobalInterceptorOrderingTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/ordering/global/GlobalInterceptorOrderingTest.java
@@ -22,20 +22,19 @@ import static org.jboss.cdi.tck.cdi.Sections.ENABLED_INTERCEPTORS;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.cdi.tck.util.ActionSequence;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Test interceptor enablement and ordering.
@@ -52,11 +51,7 @@ public class GlobalInterceptorOrderingTest extends AbstractTest {
                 // WEB-INF/classes
                 .withClasses(Dao.class, LegacyInterceptor1.class, LegacyInterceptor2.class, LegacyInterceptor3.class,
                         WebApplicationGlobalInterceptor1.class)
-                .withBeansXml(
-                        Descriptors
-                                .create(BeansDescriptor.class)
-                                .getOrCreateInterceptors().clazz(LegacyInterceptor1.class.getName(), LegacyInterceptor2.class.getName(),
-                                LegacyInterceptor3.class.getName()).clazz().up())
+                .withBeansXml(new BeansXml().interceptors(LegacyInterceptor1.class, LegacyInterceptor2.class, LegacyInterceptor3.class))
                 .withBeanLibrary(Transactional.class, AbstractInterceptor.class, Service.class,
                         GloballyEnabledInterceptor1.class, GloballyEnabledInterceptor3.class,
                         GloballyEnabledInterceptor4.class, GloballyEnabledInterceptor5.class)

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/ResolutionByNameTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/ResolutionByNameTest.java
@@ -31,6 +31,7 @@ import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
@@ -42,7 +43,7 @@ public class ResolutionByNameTest extends AbstractTest {
     @Deployment
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder().withTestClassPackage(ResolutionByNameTest.class)
-                .withBeansXml(Descriptors.create(BeansDescriptor.class).getOrCreateAlternatives().clazz(Sole.class.getName()).up())
+                .withBeansXml(new BeansXml().alternatives(Sole.class))
                 .build();
     }
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/decorator/DecoratoredBeanProxyTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/decorator/DecoratoredBeanProxyTest.java
@@ -11,6 +11,7 @@ import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
@@ -25,7 +26,8 @@ public class DecoratoredBeanProxyTest extends AbstractTest {
 	public static WebArchive createTestArchive() {
 		return new WebArchiveBuilder()
 				.withTestClassPackage(DecoratoredBeanProxyTest.class)
-				.withBeansXml(Descriptors.create(BeansDescriptor.class).getOrCreateDecorators().clazz(MarineDecorator.class.getName()).up()).build();
+				.withBeansXml(new BeansXml().decorators(MarineDecorator.class))
+				.build();
 	}
 
 	@Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/interceptor/InterceptedBeanProxyTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/interceptor/InterceptedBeanProxyTest.java
@@ -3,14 +3,12 @@ package org.jboss.cdi.tck.tests.lookup.clientProxy.unproxyable.interceptor;
 import static org.jboss.cdi.tck.cdi.Sections.UNPROXYABLE;
 
 import jakarta.enterprise.inject.spi.DeploymentException;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
@@ -25,10 +23,7 @@ public class InterceptedBeanProxyTest extends AbstractTest {
 	public static WebArchive createTestArchive() {
 		return new WebArchiveBuilder()
 				.withTestClassPackage(InterceptedBeanProxyTest.class)
-				.withBeansXml(
-						Descriptors.create(BeansDescriptor.class)
-								.getOrCreateInterceptors()
-								.clazz(FishInterceptor.class.getName()).up())
+				.withBeansXml(new BeansXml().interceptors(FishInterceptor.class))
 				.build();
 	}
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dependency/resolution/AmbiguousDependencyResolutionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dependency/resolution/AmbiguousDependencyResolutionTest.java
@@ -27,6 +27,7 @@ import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
@@ -43,9 +44,8 @@ public class AmbiguousDependencyResolutionTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder()
                 .withTestClassPackage(AmbiguousDependencyResolutionTest.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateAlternatives()
-                                .clazz(FooProducer.class.getName(), BarProducer.class.getName()).up()).build();
+                .withBeansXml(new BeansXml().alternatives(FooProducer.class, BarProducer.class))
+                .build();
     }
 
     @Test(dataProvider = ARQUILLIAN_DATA_PROVIDER)

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/destroy/dependent/DestroyingDependentInstanceTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/destroy/dependent/DestroyingDependentInstanceTest.java
@@ -22,21 +22,19 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import jakarta.enterprise.inject.Instance;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Test for CDI-139. It verifies that Instance.destroy() can be used to destroy a dependent bean instance and bean instances
@@ -56,9 +54,8 @@ public class DestroyingDependentInstanceTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder()
                 .withTestClassPackage(DestroyingDependentInstanceTest.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors()
-                                .clazz(TransactionalInterceptor.class.getName()).up()).build();
+                .withBeansXml(new BeansXml().interceptors(TransactionalInterceptor.class))
+                .build();
     }
 
     @Test(dataProvider = ARQUILLIAN_DATA_PROVIDER)

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/InjectableReferenceTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/InjectableReferenceTest.java
@@ -25,13 +25,11 @@ import jakarta.enterprise.context.spi.CreationalContext;
 import jakarta.enterprise.inject.Default;
 import jakarta.enterprise.inject.spi.Bean;
 import jakarta.enterprise.inject.spi.InjectionPoint;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
@@ -50,7 +48,8 @@ public class InjectableReferenceTest extends AbstractTest {
     @Deployment
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder().withTestClassPackage(InjectableReferenceTest.class)
-                .withBeansXml(Descriptors.create(BeansDescriptor.class).getOrCreateDecorators().clazz(TimestampLogger.class.getName()).up()).build();
+                .withBeansXml(new BeansXml().decorators(TimestampLogger.class))
+                .build();
     }
 
     @SuppressWarnings("unchecked")

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/InjectionPointTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/InjectionPointTest.java
@@ -21,6 +21,23 @@ import static org.jboss.cdi.tck.cdi.Sections.INJECTION_POINT;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Default;
+import jakarta.enterprise.inject.spi.AnnotatedField;
+import jakarta.enterprise.inject.spi.AnnotatedParameter;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.Decorator;
+import jakarta.enterprise.inject.spi.InjectionPoint;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.cdi.tck.AbstractTest;
+import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.impl.BeansXml;
+import org.jboss.test.audit.annotations.SpecAssertion;
+import org.jboss.test.audit.annotations.SpecAssertions;
+import org.jboss.test.audit.annotations.SpecVersion;
+import org.testng.annotations.Test;
+
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
@@ -29,25 +46,6 @@ import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-
-import jakarta.enterprise.context.Dependent;
-import jakarta.enterprise.inject.Default;
-import jakarta.enterprise.inject.spi.AnnotatedField;
-import jakarta.enterprise.inject.spi.AnnotatedParameter;
-import jakarta.enterprise.inject.spi.Bean;
-import jakarta.enterprise.inject.spi.Decorator;
-import jakarta.enterprise.inject.spi.InjectionPoint;
-
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.cdi.tck.AbstractTest;
-import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
-import org.jboss.test.audit.annotations.SpecAssertion;
-import org.jboss.test.audit.annotations.SpecAssertions;
-import org.jboss.test.audit.annotations.SpecVersion;
-import org.testng.annotations.Test;
 
 /**
  * Injection point metadata tests
@@ -62,9 +60,7 @@ public class InjectionPointTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder()
                 .withTestClassPackage(InjectionPointTest.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateDecorators()
-                                .clazz(AnimalDecorator1.class.getName(), AnimalDecorator2.class.getName(), AnimalDecorator3.class.getName()).up())
+                .withBeansXml(new BeansXml().decorators(AnimalDecorator1.class, AnimalDecorator2.class, AnimalDecorator3.class))
                 .build();
     }
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/provider/init/CDIProviderInitTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/provider/init/CDIProviderInitTest.java
@@ -24,15 +24,13 @@ import static org.testng.Assert.assertNotNull;
 
 import jakarta.enterprise.inject.spi.CDI;
 import jakarta.inject.Inject;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.cdi.tck.tests.extensions.alternative.deployment.Bar;
 import org.jboss.cdi.tck.tests.extensions.alternative.deployment.Foo;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
@@ -59,12 +57,12 @@ public class CDIProviderInitTest extends AbstractTest {
                 .withClasses(Alpha.class, MarkerObtainerWar.class, Foo.class, Marker.class,
                         AfterDeploymentValidationObserver.class)
                 .withExtension(AfterDeploymentValidationObserver.class)
-                .withBeansXml(Descriptors.create(BeansDescriptor.class).getOrCreateAlternatives().clazz(Alpha.class.getName()).up())
+                .withBeansXml(new BeansXml().alternatives(Alpha.class))
                 .withBeanLibrary(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateAlternatives().clazz(Bravo.class.getName()).up(),
+                        new BeansXml().alternatives(Bravo.class),
                         Bravo.class, MarkerObtainerBda1.class, Bar.class)
                 .withBeanLibrary(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateAlternatives().clazz(Charlie.class.getName()).up(),
+                        new BeansXml().alternatives(Charlie.class),
                         Charlie.class, MarkerObtainerBda2.class, Baz.class)
                 .withLibrary(MarkerObtainerNonBda.class, NonBdaAfterDeploymentValidationObserver.class).build();
     }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/provider/runtime/CDIProviderRuntimeTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/provider/runtime/CDIProviderRuntimeTest.java
@@ -26,13 +26,11 @@ import static org.testng.Assert.assertTrue;
 
 import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.enterprise.inject.spi.CDI;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
@@ -55,7 +53,7 @@ public class CDIProviderRuntimeTest extends AbstractTest {
                 .withClasses(Alpha.class, Powerful.class, PowerfulLiteral.class, AlphaLocator.class)
                 // BDA01
                 .withBeanLibrary(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateAlternatives().clazz(Bravo.class.getName()).up(),
+                        new BeansXml().alternatives(Bravo.class),
                         Bravo.class, BravoLocator.class, BravoMarker.class).build();
     }
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/SelectedAlternativeManagedBeanInjectionAvailability02Test.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/SelectedAlternativeManagedBeanInjectionAvailability02Test.java
@@ -19,13 +19,11 @@ package org.jboss.cdi.tck.tests.lookup.modules;
 import static org.jboss.cdi.tck.cdi.Sections.INTER_MODULE_INJECTION;
 
 import jakarta.inject.Inject;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.Assert;
@@ -38,7 +36,7 @@ public class SelectedAlternativeManagedBeanInjectionAvailability02Test extends A
     public static WebArchive createTestArchive() {
         WebArchive webArchive = new WebArchiveBuilder().withTestClass(SelectedAlternativeManagedBeanInjectionAvailability02Test.class)
                 .withClasses(AlternativeFoo.class).withBeanLibrary(Foo.class, Bar.class)
-                .withBeanLibrary(Descriptors.create(BeansDescriptor.class).getOrCreateAlternatives().clazz(AlternativeFoo.class.getName()).up(), WebBar.class)
+                .withBeanLibrary(new BeansXml().alternatives(AlternativeFoo.class), WebBar.class)
                 .build();
 
         return webArchive;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/SelectedAlternativeManagedBeanInjectionAvailabilityTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/SelectedAlternativeManagedBeanInjectionAvailabilityTest.java
@@ -20,14 +20,12 @@ import static org.jboss.cdi.tck.TestGroups.JAVAEE_FULL;
 import static org.jboss.cdi.tck.cdi.Sections.INTER_MODULE_INJECTION;
 
 import jakarta.inject.Inject;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.EnterpriseArchiveBuilder;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.Assert;
@@ -57,9 +55,8 @@ public class SelectedAlternativeManagedBeanInjectionAvailabilityTest extends Abs
         enterpriseArchive.addAsModule(new WebArchiveBuilder()
                 .notTestArchive()
                 .withDefaultEjbModuleDependency()
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateAlternatives().clazz(AlternativeFoo.class.getName())
-                                .up()).withClasses(SelectedAlternativeManagedBeanInjectionAvailabilityTest.class, WebBar.class)
+                .withBeansXml(new BeansXml().alternatives(AlternativeFoo.class))
+                .withClasses(SelectedAlternativeManagedBeanInjectionAvailabilityTest.class, WebBar.class)
                 .build());
 
         return enterpriseArchive;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/SelectedAlternativeSessionBeanInjectionAvailability02Test.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/SelectedAlternativeSessionBeanInjectionAvailability02Test.java
@@ -20,13 +20,11 @@ import static org.jboss.cdi.tck.TestGroups.INTEGRATION;
 import static org.jboss.cdi.tck.cdi.Sections.SELECTION_EE;
 
 import jakarta.inject.Inject;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.Assert;
@@ -40,7 +38,7 @@ public class SelectedAlternativeSessionBeanInjectionAvailability02Test extends A
 
         WebArchive webArchive = new WebArchiveBuilder().withTestClass(SelectedAlternativeSessionBeanInjectionAvailability02Test.class)
                 .withClasses(AlternativeEjbFoo.class, EjbFooLocal.class).withBeanLibrary(Foo.class, Bar.class)
-                .withBeanLibrary(Descriptors.create(BeansDescriptor.class).getOrCreateAlternatives().clazz(AlternativeEjbFoo.class.getName()).up(), WebBar.class)
+                .withBeanLibrary(new BeansXml().alternatives(AlternativeEjbFoo.class), WebBar.class)
                 .build();
 
         return webArchive;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/SelectedAlternativeSessionBeanInjectionAvailabilityTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/SelectedAlternativeSessionBeanInjectionAvailabilityTest.java
@@ -28,6 +28,7 @@ import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.Assert;
@@ -57,9 +58,8 @@ public class SelectedAlternativeSessionBeanInjectionAvailabilityTest extends Abs
         enterpriseArchive.addAsModule(new WebArchiveBuilder()
                 .withDefaultEjbModuleDependency()
                 .notTestArchive()
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateAlternatives().clazz(AlternativeEjbFoo.class.getName())
-                                .up()).withClasses(SelectedAlternativeSessionBeanInjectionAvailabilityTest.class, WebBar.class)
+                .withBeansXml(new BeansXml().alternatives(AlternativeEjbFoo.class))
+                .withClasses(SelectedAlternativeSessionBeanInjectionAvailabilityTest.class, WebBar.class)
                 .build());
 
         return enterpriseArchive;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/interceptors/InterceptorModularityTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/interceptors/InterceptorModularityTest.java
@@ -23,7 +23,6 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 import jakarta.enterprise.inject.Instance;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.Testable;
 import org.jboss.cdi.tck.AbstractTest;
@@ -37,8 +36,8 @@ import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
 import org.jboss.shrinkwrap.descriptor.api.spec.se.manifest.ManifestDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -61,7 +60,7 @@ public class InterceptorModularityTest extends AbstractTest {
         EnterpriseArchive enterpriseArchive = new EnterpriseArchiveBuilder()
                 .withTestClassDefinition(InterceptorModularityTest.class)
                 .withClasses(Checker.class, BarBinding.class, Animal.class, Cow.class, BarSuperInterceptor.class)
-                .withBeansXml(Descriptors.create(BeansDescriptor.class).getOrCreateAlternatives().clazz(Cow.class.getName()).up())
+                .withBeansXml(new BeansXml().alternatives(Cow.class))
                 .noDefaultWebModule().build();
 
         JavaArchive fooArchive = ShrinkWrap.create(JavaArchive.class, TEST1_JAR)

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/alternative/Specialization02Test.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/alternative/Specialization02Test.java
@@ -28,13 +28,11 @@ import static org.testng.Assert.assertTrue;
 import jakarta.enterprise.event.Event;
 import jakarta.enterprise.inject.Alternative;
 import jakarta.inject.Inject;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
@@ -56,7 +54,7 @@ public class Specialization02Test extends AbstractTest {
         return new WebArchiveBuilder()
                 .withTestClass(Specialization02Test.class)
                 .withBeanLibrary(InjectedBean1.class)
-                .withBeanLibrary(Descriptors.create(BeansDescriptor.class).getOrCreateAlternatives().clazz(AlternativeSpecializedFactory.class.getName()).up(),
+                .withBeanLibrary(new BeansXml().alternatives(AlternativeSpecializedFactory.class),
                         Factory.class, AlternativeSpecializedFactory.class, Product.class, InjectedBean2.class, FactoryEvent.class).build();
     }
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/alternative/Specialization03Test.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/alternative/Specialization03Test.java
@@ -28,13 +28,11 @@ import static org.testng.Assert.assertTrue;
 import jakarta.enterprise.event.Event;
 import jakarta.enterprise.inject.Alternative;
 import jakarta.inject.Inject;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
@@ -64,7 +62,7 @@ public class Specialization03Test extends AbstractTest {
         return new WebArchiveBuilder()
                 .withTestClass(Specialization03Test.class)
                 .withBeanLibrary(Factory.class, AlternativeSpecializedFactory.class, Product.class, InjectedBean2.class, FactoryEvent.class)
-                .withBeanLibrary(Descriptors.create(BeansDescriptor.class).getOrCreateAlternatives().clazz(AlternativeSpecializedFactory.class.getName()).up(),
+                .withBeanLibrary(new BeansXml().alternatives(AlternativeSpecializedFactory.class),
                         InjectedBean1.class).build();
     }
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/alternative/Specialization04Test.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/alternative/Specialization04Test.java
@@ -26,13 +26,11 @@ import static org.testng.Assert.assertTrue;
 import jakarta.enterprise.event.Event;
 import jakarta.enterprise.inject.Alternative;
 import jakarta.inject.Inject;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
@@ -61,9 +59,8 @@ public class Specialization04Test extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder()
                 .withTestClass(Specialization04Test.class)
-                .withBeanLibrary(Descriptors.create(BeansDescriptor.class).getOrCreateAlternatives().clazz(AlternativeSpecializedFactory.class.getName()).up(),
-                        Factory.class, AlternativeSpecializedFactory.class, Product.class, InjectedBean2.class, FactoryEvent.class)
-                .withBeanLibrary(Descriptors.create(BeansDescriptor.class).getOrCreateAlternatives().clazz(AlternativeSpecializedFactory.class.getName()).up(),
+                .withBeanLibrary(new BeansXml().alternatives(AlternativeSpecializedFactory.class), Factory.class, AlternativeSpecializedFactory.class, Product.class, InjectedBean2.class, FactoryEvent.class)
+                .withBeanLibrary(new BeansXml().alternatives(AlternativeSpecializedFactory.class),
                         InjectedBean1.class).build();
     }
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/alternative/Specialization05Test.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/alternative/Specialization05Test.java
@@ -11,14 +11,12 @@ import static org.testng.Assert.assertTrue;
 
 import jakarta.enterprise.event.Event;
 import jakarta.inject.Inject;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.EnterpriseArchiveBuilder;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
@@ -42,8 +40,8 @@ public class Specialization05Test extends AbstractTest {
                 .withTestClassDefinition(Specialization05Test.class)
                 .noDefaultWebModule()
                 .withBeanLibrary(Factory.class, Product.class, InjectedBean1.class, FactoryEvent.class)
-                .withBeanLibrary(Descriptors.create(BeansDescriptor.class).getOrCreateAlternatives().clazz(AlternativeSpecializedFactory.class.getName()).up(),
-                        AlternativeSpecializedFactory.class).build();
+                .withBeanLibrary(new BeansXml().alternatives(AlternativeSpecializedFactory.class), AlternativeSpecializedFactory.class)
+                .build();
 
         enterpriseArchive.addAsModule(new WebArchiveBuilder().notTestArchive().withDefaultEjbModuleDependency()
                 .withClasses(InjectedBean2.class,Specialization05Test.class).build());

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/interceptor/InterceptorNotResolvedTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/interceptor/InterceptorNotResolvedTest.java
@@ -27,6 +27,7 @@ import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -40,9 +41,8 @@ public class InterceptorNotResolvedTest extends AbstractTest {
         return new WebArchiveBuilder()
                 .withTestClass(InterceptorNotResolvedTest.class)
                 .withClasses(Cat.class, CatInterceptor.class, CatInterceptorBinding.class, Foo.class)
-                .withBeansXml(
-                        Descriptors.create(BeansDescriptor.class).getOrCreateInterceptors().clazz(CatInterceptor.class.getName())
-                                .up()).build();
+                .withBeansXml(new BeansXml().interceptors(CatInterceptor.class))
+                .build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/shrinkwrap/api/BeanDiscoveryMode.java
+++ b/impl/src/main/java/org/jboss/shrinkwrap/api/BeanDiscoveryMode.java
@@ -1,0 +1,16 @@
+package org.jboss.shrinkwrap.api;
+
+public enum BeanDiscoveryMode {
+
+    NONE("none"), ANNOTATED("annotated"), ALL("all");
+
+    private final String value;
+
+    private BeanDiscoveryMode(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/impl/src/main/java/org/jboss/shrinkwrap/api/BeansXmlVersion.java
+++ b/impl/src/main/java/org/jboss/shrinkwrap/api/BeansXmlVersion.java
@@ -1,0 +1,16 @@
+package org.jboss.shrinkwrap.api;
+
+public enum BeansXmlVersion {
+
+    v30("3.0"), v20("2.0"), v11("1.1");
+
+    private final String value;
+
+    private BeansXmlVersion(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/impl/src/main/java/org/jboss/shrinkwrap/impl/BeansXml.java
+++ b/impl/src/main/java/org/jboss/shrinkwrap/impl/BeansXml.java
@@ -1,0 +1,300 @@
+package org.jboss.shrinkwrap.impl;
+
+import org.jboss.shrinkwrap.api.BeanDiscoveryMode;
+import org.jboss.shrinkwrap.api.BeansXmlVersion;
+import org.jboss.shrinkwrap.api.asset.Asset;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Allows to create a beans.xml file programmatically.
+ * By default it uses discovery mode all and has version 3.0
+ */
+public class BeansXml implements Asset {
+
+    public static final BeansXml SUPPRESSOR = new BeansXml(Collections.<Class<?>> emptyList(), Collections.<Class<?>> emptyList(), Collections.<Class<?>> emptyList(), Collections.<Class<?>> emptyList(), Collections.<Exclude> emptyList()) {
+        @Override
+        public BeanDiscoveryMode getBeanDiscoveryMode() {
+            return BeanDiscoveryMode.NONE;
+        }
+    };
+
+    private static final String CLOSING_TAG_PREFIX = "</";
+    private static final String OPENING_TAG_PREFIX = "<";
+    private static final String TAG_SUFFIX = ">";
+    private static final String TAG_SUFFIX_NEW_LINE = ">\n";
+    private static final String TAG_SUFFIX_SELF_CLOSE_NEW_LINE = " />\n";
+    private static final String ALTERNATIVES_ELEMENT_NAME = "alternatives";
+    private static final String CLASS = "class";
+
+    private static final String SCAN_ELEMENT_NAME = "scan";
+    private static final String EXCLUDE_ELEMENT_NAME = "exclude";
+    private static final String IF_SYSTEM_PROPERTY_ELEMENT_NAME = "if-system-property";
+    private static final String IF_CLASS_AVAILABLE_ELEMENT_NAME = "if-class-available";
+    private static final String IF_CLASS_NOT_AVAILABLE_ELEMENT_NAME = "if-class-not-available";
+    private static final String NAME_ATTRIBUTE_NAME = "name";
+    private static final String VALUE_ATTRIBUTE_NAME = "value";
+
+    private final List<Class<?>> alternatives;
+    private final List<Class<?>> interceptors;
+    private final List<Class<?>> decorators;
+    private final List<Class<?>> stereotypes;
+    private final List<Exclude> excludeFilters;
+
+    // defaults
+    private BeanDiscoveryMode mode = BeanDiscoveryMode.ALL;
+    private BeansXmlVersion version = BeansXmlVersion.v30;
+
+    public static class Exclude {
+
+        private final String classFilter;
+        private final List<Condition> conditions;
+
+        private Exclude(String classFilter) {
+            this.classFilter = classFilter;
+            conditions = new ArrayList<Condition>();
+        }
+
+        public static Exclude match(String classFilter) {
+            return new Exclude(classFilter);
+        }
+
+        public static Exclude exact(Class<?> clazz) {
+            return new Exclude(clazz.getName());
+        }
+
+        public Exclude ifSystemProperty(String name) {
+            conditions.add(new IfSystemProperty(name, null));
+            return this;
+        }
+
+        public Exclude ifSystemProperty(String name, String value) {
+            conditions.add(new IfSystemProperty(name, value));
+            return this;
+        }
+
+        public Exclude ifClassAvailable(Class<?> clazz) {
+            return ifClassAvailable(clazz.getName());
+        }
+
+        public Exclude ifClassAvailable(String className) {
+            conditions.add(new IfClassAvailable(className));
+            return this;
+        }
+
+        public Exclude ifClassNotAvailable(Class<?> clazz) {
+            return ifClassNotAvailable(clazz.getName());
+        }
+
+        public Exclude ifClassNotAvailable(String className) {
+            conditions.add(new IfClassNotAvailable(className));
+            return this;
+        }
+
+        public String getClassFilter() {
+            return this.classFilter;
+        }
+
+        public List<Condition> getConditions() {
+            return this.conditions;
+        }
+
+        private static class Condition {
+            private final String nameParam;
+            private final String tagName;
+
+            public Condition(String tagName, String nameParam) {
+                this.tagName = tagName;
+                this.nameParam = nameParam;
+            }
+
+            public String getName() {
+                return this.nameParam;
+            }
+
+            public String getTagName() {
+                return this.tagName;
+            }
+
+            @Override
+            public String toString() {
+                StringBuilder sb = new StringBuilder();
+                sb.append(OPENING_TAG_PREFIX).append(getTagName());
+                appendAttribute(NAME_ATTRIBUTE_NAME, getName(), sb);
+                sb.append(TAG_SUFFIX_SELF_CLOSE_NEW_LINE);
+                return sb.toString();
+            }
+
+        }
+
+        private static class IfSystemProperty extends Condition {
+
+            private final String value;
+
+            public IfSystemProperty(String name, String value) {
+                super(IF_SYSTEM_PROPERTY_ELEMENT_NAME, name);
+                this.value = value;
+            }
+
+            public String getValue() {
+                return this.value;
+            }
+
+            @Override
+            public String toString() {
+                StringBuilder sb = new StringBuilder();
+                sb.append(OPENING_TAG_PREFIX).append(getTagName());
+                appendAttribute(NAME_ATTRIBUTE_NAME, getName(), sb);
+                if (value != null) {
+                    appendAttribute(VALUE_ATTRIBUTE_NAME, getValue(), sb);
+                }
+                sb.append(TAG_SUFFIX_SELF_CLOSE_NEW_LINE);
+                return sb.toString();
+            }
+
+        }
+
+        private static class IfClassAvailable extends Condition {
+
+            public IfClassAvailable(String className) {
+                super(IF_CLASS_AVAILABLE_ELEMENT_NAME, className);
+            }
+
+        }
+
+        private static class IfClassNotAvailable extends Condition {
+
+            public IfClassNotAvailable(String className) {
+                super(IF_CLASS_NOT_AVAILABLE_ELEMENT_NAME, className);
+            }
+        }
+
+    }
+
+    public BeansXml() {
+        this(new ArrayList<Class<?>>(), new ArrayList<Class<?>>(), new ArrayList<Class<?>>(), new ArrayList<Class<?>>(), new ArrayList<Exclude>());
+    }
+
+    public BeansXml(BeanDiscoveryMode mode) {
+        this();
+        setBeanDiscoveryMode(mode);
+    }
+
+    private BeansXml(List<Class<?>> alternatives, List<Class<?>> interceptors, List<Class<?>> decorators, List<Class<?>> stereotypes, List<Exclude> excludeFilters) {
+        this.alternatives = alternatives;
+        this.interceptors = interceptors;
+        this.decorators = decorators;
+        this.stereotypes = stereotypes;
+        this.excludeFilters = excludeFilters;
+    }
+
+    public BeansXml alternatives(Class<?>... alternatives) {
+        this.alternatives.addAll(Arrays.asList(alternatives));
+        return this;
+    }
+
+    public BeansXml interceptors(Class<?>... interceptors) {
+        this.interceptors.addAll(Arrays.asList(interceptors));
+        return this;
+    }
+
+    public BeansXml decorators(Class<?>... decorators) {
+        this.decorators.addAll(Arrays.asList(decorators));
+        return this;
+    }
+
+    public BeansXml stereotype(Class<?>... stereotypes) {
+        this.stereotypes.addAll(Arrays.asList(stereotypes));
+        return this;
+    }
+
+    public BeansXml excludeFilters(Exclude... filters) {
+        this.excludeFilters.addAll(Arrays.asList(filters));
+        return this;
+    }
+
+    public BeansXml setBeansXmlVersion(BeansXmlVersion version) {
+        this.version = version;
+        return this;
+    }
+
+    public BeanDiscoveryMode getBeanDiscoveryMode() {
+        return mode;
+    }
+
+    public BeansXmlVersion getBeansXmlVersion() {
+        return version;
+    }
+
+    public void setBeanDiscoveryMode(BeanDiscoveryMode mode) {
+        this.mode = mode;
+    }
+
+    @Override
+    public InputStream openStream() {
+        StringBuilder xml = new StringBuilder();
+        xml.append("<beans version=\"" + getBeansXmlVersion().getValue() + "\" bean-discovery-mode=\"");
+        xml.append(getBeanDiscoveryMode().getValue());
+        xml.append("\">\n");
+        appendExcludeFilters(excludeFilters, xml);
+        appendAlternatives(alternatives, stereotypes, xml);
+        appendSection("interceptors", CLASS, interceptors, xml);
+        appendSection("decorators", CLASS, decorators, xml);
+        xml.append("</beans>");
+
+        return new ByteArrayInputStream(xml.toString().getBytes());
+    }
+
+    private void appendExcludeFilters(List<Exclude> filters, StringBuilder xml) {
+        if (filters.size() > 0) {
+            xml.append(OPENING_TAG_PREFIX).append(SCAN_ELEMENT_NAME).append(TAG_SUFFIX_NEW_LINE);
+            for(Exclude ex : filters) {
+                xml.append(OPENING_TAG_PREFIX).append(EXCLUDE_ELEMENT_NAME);
+                appendAttribute(NAME_ATTRIBUTE_NAME, ex.getClassFilter(), xml);
+                List<Exclude.Condition> conditions = ex.getConditions();
+                if(conditions.isEmpty()) {
+                    xml.append(TAG_SUFFIX_SELF_CLOSE_NEW_LINE);
+                } else {
+                    xml.append(TAG_SUFFIX_NEW_LINE);
+                    for (Exclude.Condition c : conditions) {
+                        xml.append(c.toString());
+                    }
+                    xml.append(CLOSING_TAG_PREFIX).append(EXCLUDE_ELEMENT_NAME).append(TAG_SUFFIX_NEW_LINE);
+                }
+            }
+            xml.append(CLOSING_TAG_PREFIX).append(SCAN_ELEMENT_NAME).append(TAG_SUFFIX_NEW_LINE);
+        }
+    }
+
+    private static void appendAttribute(String name, String value, StringBuilder xml) {
+        xml.append(" ").append(name).append("=\"").append(value).append("\"");
+    }
+
+    private static void appendAlternatives(List<Class<?>> alternatives, List<Class<?>> stereotypes, StringBuilder xml) {
+        if (alternatives.size() > 0 || stereotypes.size() > 0) {
+            xml.append(OPENING_TAG_PREFIX).append(ALTERNATIVES_ELEMENT_NAME).append(TAG_SUFFIX_NEW_LINE);
+            appendClasses(CLASS, alternatives, xml);
+            appendClasses("stereotype", stereotypes, xml);
+            xml.append(CLOSING_TAG_PREFIX).append(ALTERNATIVES_ELEMENT_NAME).append(TAG_SUFFIX_NEW_LINE);
+        }
+    }
+
+    private static void appendSection(String name, String subName, List<Class<?>> classes, StringBuilder xml) {
+        if (classes.size() > 0) {
+            xml.append(OPENING_TAG_PREFIX).append(name).append(TAG_SUFFIX_NEW_LINE);
+            appendClasses(subName, classes, xml);
+            xml.append(CLOSING_TAG_PREFIX).append(name).append(TAG_SUFFIX_NEW_LINE);
+        }
+    }
+
+    private static void appendClasses(String name, List<Class<?>> classes, StringBuilder xml) {
+        for (Class<?> clazz : classes) {
+            xml.append(OPENING_TAG_PREFIX).append(name).append(TAG_SUFFIX).append(clazz.getName()).append(CLOSING_TAG_PREFIX).append(name).append(TAG_SUFFIX_NEW_LINE);
+        }
+    }
+}

--- a/impl/src/main/resources/org/jboss/cdi/tck/tests/alternative/broken/incorrect/name/beans.xml
+++ b/impl/src/main/resources/org/jboss/cdi/tck/tests/alternative/broken/incorrect/name/beans.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+         https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       version="3.0" bean-discovery-mode="all">
+    <alternatives>
+        <class>org.jboss.cdi.tck.tests.alternative.broken.incorrect.name.NonExistingClass</class>
+    </alternatives>
+</beans>

--- a/impl/src/main/resources/org/jboss/cdi/tck/tests/alternative/broken/incorrect/name/stereotype/beans.xml
+++ b/impl/src/main/resources/org/jboss/cdi/tck/tests/alternative/broken/incorrect/name/stereotype/beans.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+         https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       version="3.0" bean-discovery-mode="all">
+    <alternatives>
+        <stereotype>org.jboss.cdi.tck.tests.policy.broken.incorrect.name.stereotype.Mock</stereotype>
+    </alternatives>
+</beans>

--- a/impl/src/main/resources/org/jboss/cdi/tck/tests/alternative/enterprise/beans.xml
+++ b/impl/src/main/resources/org/jboss/cdi/tck/tests/alternative/enterprise/beans.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd" version="1.1" bean-discovery-mode="all">
+	   xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd" version="3.0" bean-discovery-mode="all">
 	<alternatives>
 		<class>org.jboss.cdi.tck.tests.alternative.enterprise.EnabledEjb</class>
 	</alternatives>

--- a/impl/src/main/resources/org/jboss/cdi/tck/tests/context/dependent/beans.xml
+++ b/impl/src/main/resources/org/jboss/cdi/tck/tests/context/dependent/beans.xml
@@ -1,6 +1,6 @@
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd" version="1.1" bean-discovery-mode="all">
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd" version="3.0" bean-discovery-mode="all">
    <decorators>
       <class>org.jboss.cdi.tck.tests.context.dependent.InteriorDecorator</class>
    </decorators>

--- a/impl/src/main/resources/org/jboss/cdi/tck/tests/context/passivating/broken/decoratorWithNonPassivatingBeanConstructor/beans.xml
+++ b/impl/src/main/resources/org/jboss/cdi/tck/tests/context/passivating/broken/decoratorWithNonPassivatingBeanConstructor/beans.xml
@@ -1,6 +1,6 @@
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd" version="1.1" bean-discovery-mode="all">
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd" version="3.0" bean-discovery-mode="all">
    <decorators>
       <class>org.jboss.cdi.tck.tests.context.passivating.broken.decoratorWithNonPassivatingBeanConstructor.CityDecorator</class>
    </decorators>

--- a/impl/src/main/resources/org/jboss/cdi/tck/tests/context/passivating/broken/decoratorWithNonPassivatingInitializerMethod/beans.xml
+++ b/impl/src/main/resources/org/jboss/cdi/tck/tests/context/passivating/broken/decoratorWithNonPassivatingInitializerMethod/beans.xml
@@ -1,6 +1,6 @@
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd" version="1.1" bean-discovery-mode="all">
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd" version="3.0" bean-discovery-mode="all">
    <decorators>
       <class>org.jboss.cdi.tck.tests.context.passivating.broken.decoratorWithNonPassivatingInitializerMethod.CityDecorator</class>
    </decorators>

--- a/impl/src/main/resources/org/jboss/cdi/tck/tests/context/passivating/broken/enterpriseBeanWithNonPassivatingBeanConstructorParameterInInterceptor/beans.xml
+++ b/impl/src/main/resources/org/jboss/cdi/tck/tests/context/passivating/broken/enterpriseBeanWithNonPassivatingBeanConstructorParameterInInterceptor/beans.xml
@@ -1,6 +1,6 @@
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd" version="1.1" bean-discovery-mode="all">
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd" version="3.0" bean-discovery-mode="all">
     <interceptors>
         <class>org.jboss.cdi.tck.tests.context.passivating.broken.enterpriseBeanWithNonPassivatingBeanConstructorParameterInInterceptor.BrokenInterceptor</class>
     </interceptors>

--- a/impl/src/main/resources/org/jboss/cdi/tck/tests/context/passivating/broken/enterpriseBeanWithNonPassivatingConstructorFieldInDecorator/beans.xml
+++ b/impl/src/main/resources/org/jboss/cdi/tck/tests/context/passivating/broken/enterpriseBeanWithNonPassivatingConstructorFieldInDecorator/beans.xml
@@ -1,6 +1,6 @@
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd" version="1.1" bean-discovery-mode="all">
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd" version="3.0" bean-discovery-mode="all">
    <decorators>
       <class>org.jboss.cdi.tck.tests.context.passivating.broken.enterpriseBeanWithNonPassivatingConstructorFieldInDecorator.BrokenDecorator</class>
    </decorators>

--- a/impl/src/main/resources/org/jboss/cdi/tck/tests/context/passivating/broken/enterpriseBeanWithNonPassivatingInitializerInDecorator/beans.xml
+++ b/impl/src/main/resources/org/jboss/cdi/tck/tests/context/passivating/broken/enterpriseBeanWithNonPassivatingInitializerInDecorator/beans.xml
@@ -1,6 +1,6 @@
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd" version="1.1" bean-discovery-mode="all">
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd" version="3.0" bean-discovery-mode="all">
    <decorators>
       <class>org.jboss.cdi.tck.tests.context.passivating.broken.enterpriseBeanWithNonPassivatingInitializerInDecorator.BrokenDecorator</class>
    </decorators>

--- a/impl/src/main/resources/org/jboss/cdi/tck/tests/context/passivating/broken/enterpriseBeanWithNonPassivatingInitializerParameterInInterceptor/beans.xml
+++ b/impl/src/main/resources/org/jboss/cdi/tck/tests/context/passivating/broken/enterpriseBeanWithNonPassivatingInitializerParameterInInterceptor/beans.xml
@@ -1,6 +1,6 @@
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd" version="1.1" bean-discovery-mode="all">
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd" version="3.0" bean-discovery-mode="all">
   <interceptors>
     <class>org.jboss.cdi.tck.tests.context.passivating.broken.enterpriseBeanWithNonPassivatingInitializerParameterInInterceptor.BrokenInterceptor</class>
   </interceptors>

--- a/impl/src/main/resources/org/jboss/cdi/tck/tests/context/passivating/broken/interceptorWithNonPassivatingBeanConstructorParameter/beans.xml
+++ b/impl/src/main/resources/org/jboss/cdi/tck/tests/context/passivating/broken/interceptorWithNonPassivatingBeanConstructorParameter/beans.xml
@@ -1,6 +1,6 @@
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd" version="1.1" bean-discovery-mode="all">
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd" version="3.0" bean-discovery-mode="all">
   <interceptors>
     <class>org.jboss.cdi.tck.tests.context.passivating.broken.interceptorWithNonPassivatingBeanConstructorParameter.BrokenInterceptor</class>
   </interceptors>

--- a/impl/src/main/resources/org/jboss/cdi/tck/tests/decorators/custom/beans.xml
+++ b/impl/src/main/resources/org/jboss/cdi/tck/tests/decorators/custom/beans.xml
@@ -1,6 +1,6 @@
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd" version="1.1" bean-discovery-mode="all">
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd" version="3.0" bean-discovery-mode="all">
    <decorators>
       <class>org.jboss.cdi.tck.tests.decorators.custom.VehicleDecorator</class>
    </decorators>

--- a/impl/src/main/resources/org/jboss/cdi/tck/tests/decorators/definition/broken/nonExistantClassInBeansXml/beans.xml
+++ b/impl/src/main/resources/org/jboss/cdi/tck/tests/decorators/definition/broken/nonExistantClassInBeansXml/beans.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+         https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       version="3.0" bean-discovery-mode="all">
+    <decorators>
+        <class>com.acme.NonExistentDecoratorClass</class>
+    </decorators>
+</beans>

--- a/impl/src/main/resources/org/jboss/cdi/tck/tests/decorators/definition/inject/delegateConstructor/beans.xml
+++ b/impl/src/main/resources/org/jboss/cdi/tck/tests/decorators/definition/inject/delegateConstructor/beans.xml
@@ -1,6 +1,6 @@
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd" version="1.1" bean-discovery-mode="all">
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd" version="3.0" bean-discovery-mode="all">
    <decorators>
       <class>org.jboss.cdi.tck.tests.decorators.definition.inject.delegateConstructor.TimestampLogger</class>
    </decorators>

--- a/impl/src/main/resources/org/jboss/cdi/tck/tests/decorators/definition/inject/delegateField/beans.xml
+++ b/impl/src/main/resources/org/jboss/cdi/tck/tests/decorators/definition/inject/delegateField/beans.xml
@@ -1,6 +1,6 @@
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd" version="1.1" bean-discovery-mode="all">
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd" version="3.0" bean-discovery-mode="all">
    <decorators>
       <class>org.jboss.cdi.tck.tests.decorators.definition.inject.delegateField.TimestampLogger</class>
    </decorators>

--- a/impl/src/main/resources/org/jboss/cdi/tck/tests/decorators/definition/inject/delegateInitializerMethod/beans.xml
+++ b/impl/src/main/resources/org/jboss/cdi/tck/tests/decorators/definition/inject/delegateInitializerMethod/beans.xml
@@ -1,6 +1,6 @@
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd" version="1.1" bean-discovery-mode="all">
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd" version="3.0" bean-discovery-mode="all">
    <decorators>
       <class>org.jboss.cdi.tck.tests.decorators.definition.inject.delegateInitializerMethod.TimestampLogger</class>
    </decorators>

--- a/impl/src/main/resources/org/jboss/cdi/tck/tests/decorators/invocation/observer/beans.xml
+++ b/impl/src/main/resources/org/jboss/cdi/tck/tests/decorators/invocation/observer/beans.xml
@@ -1,6 +1,6 @@
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd" version="1.1" bean-discovery-mode="all">
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd" version="3.0" bean-discovery-mode="all">
    <decorators>
       <class>org.jboss.cdi.tck.tests.decorators.invocation.observer.ObserverDecorator</class>
    </decorators>

--- a/impl/src/main/resources/org/jboss/cdi/tck/tests/decorators/invocation/producer/method/beans.xml
+++ b/impl/src/main/resources/org/jboss/cdi/tck/tests/decorators/invocation/producer/method/beans.xml
@@ -1,6 +1,6 @@
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd" version="1.1" bean-discovery-mode="all">
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd" version="3.0" bean-discovery-mode="all">
    <decorators>
       <class>org.jboss.cdi.tck.tests.decorators.invocation.producer.method.ProducerDecorator</class>
    </decorators>

--- a/impl/src/main/resources/org/jboss/cdi/tck/tests/decorators/resolution/beans.xml
+++ b/impl/src/main/resources/org/jboss/cdi/tck/tests/decorators/resolution/beans.xml
@@ -1,6 +1,6 @@
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd" version="1.1" bean-discovery-mode="all">
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd" version="3.0" bean-discovery-mode="all">
    <decorators>
       <class>org.jboss.cdi.tck.tests.decorators.resolution.BarDecorator</class>
       <class>org.jboss.cdi.tck.tests.decorators.resolution.FooDecorator</class>

--- a/impl/src/main/resources/org/jboss/cdi/tck/tests/deployment/discovery/enterprise/beans.xml
+++ b/impl/src/main/resources/org/jboss/cdi/tck/tests/deployment/discovery/enterprise/beans.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+         https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd" >
+</beans>

--- a/impl/src/main/resources/org/jboss/cdi/tck/tests/deployment/trimmed/beans.xml
+++ b/impl/src/main/resources/org/jboss/cdi/tck/tests/deployment/trimmed/beans.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd" version="2.0" bean-discovery-mode="all">
+	   xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd" version="3.0" bean-discovery-mode="all">
 	<trim/>
 </beans>

--- a/impl/src/main/resources/org/jboss/cdi/tck/tests/deployment/trimmed/enteprise/beans.xml
+++ b/impl/src/main/resources/org/jboss/cdi/tck/tests/deployment/trimmed/enteprise/beans.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd" version="2.0" bean-discovery-mode="all">
+	   xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd" version="3.0" bean-discovery-mode="all">
 	<trim/>
 </beans>

--- a/impl/src/main/resources/org/jboss/cdi/tck/tests/interceptors/definition/broken/nonExistantClassInBeansXml/beans.xml
+++ b/impl/src/main/resources/org/jboss/cdi/tck/tests/interceptors/definition/broken/nonExistantClassInBeansXml/beans.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+         https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       version="3.0" bean-discovery-mode="all">
+    <interceptors>
+        <class>com.acme.Foo</class>
+    </interceptors>
+</beans>

--- a/impl/src/main/resources/org/jboss/cdi/tck/tests/interceptors/definition/custom/beans.xml
+++ b/impl/src/main/resources/org/jboss/cdi/tck/tests/interceptors/definition/custom/beans.xml
@@ -1,6 +1,6 @@
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd" version="1.1" bean-discovery-mode="all">
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd" version="3.0" bean-discovery-mode="all">
   <interceptors>
     <class>org.jboss.cdi.tck.tests.interceptors.definition.custom.SimpleInterceptorWithoutAnnotations</class>
   </interceptors>

--- a/impl/src/main/resources/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/interceptorOrder/beans.xml
+++ b/impl/src/main/resources/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/interceptorOrder/beans.xml
@@ -1,6 +1,6 @@
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd" version="1.1" bean-discovery-mode="all">
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd" version="3.0" bean-discovery-mode="all">
     <interceptors>
         <class>org.jboss.cdi.tck.tests.interceptors.definition.enterprise.interceptorOrder.MissileInterceptor</class>
     </interceptors>

--- a/impl/src/main/resources/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/nonContextualReference/beans.xml
+++ b/impl/src/main/resources/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/nonContextualReference/beans.xml
@@ -1,6 +1,6 @@
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd" version="1.1" bean-discovery-mode="all">
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd" version="3.0" bean-discovery-mode="all">
   <interceptors>
     <class>org.jboss.cdi.tck.tests.interceptors.definition.enterprise.nonContextualReference.MissileInterceptor</class>
     <class>org.jboss.cdi.tck.tests.interceptors.definition.enterprise.nonContextualReference.AnchorInterceptor</class>

--- a/impl/src/main/resources/org/jboss/cdi/tck/tests/interceptors/definition/interceptorCalledBeforeDecorator/beans.xml
+++ b/impl/src/main/resources/org/jboss/cdi/tck/tests/interceptors/definition/interceptorCalledBeforeDecorator/beans.xml
@@ -1,6 +1,6 @@
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd" version="1.1" bean-discovery-mode="all">
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd" version="3.0" bean-discovery-mode="all">
   <decorators>
     <class>org.jboss.cdi.tck.tests.interceptors.definition.interceptorCalledBeforeDecorator.FooDecorator</class>
   </decorators>

--- a/impl/src/main/resources/org/jboss/cdi/tck/tests/interceptors/definition/interceptorNotListedInBeansXml/beans.xml
+++ b/impl/src/main/resources/org/jboss/cdi/tck/tests/interceptors/definition/interceptorNotListedInBeansXml/beans.xml
@@ -1,6 +1,6 @@
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd" version="1.1" bean-discovery-mode="all">
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd" version="3.0" bean-discovery-mode="all">
   <interceptors>
 
   </interceptors>

--- a/impl/src/main/resources/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/decorator/beans.xml
+++ b/impl/src/main/resources/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/decorator/beans.xml
@@ -1,6 +1,6 @@
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd" version="1.1" bean-discovery-mode="all">
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd" version="3.0" bean-discovery-mode="all">
    <decorators>
       <class>org.jboss.cdi.tck.tests.lookup.typesafe.resolution.decorator.AnimalDecorator</class>
    </decorators>

--- a/impl/src/main/resources/org/jboss/cdi/tck/tests/se/discovery/trimmed/beans.xml
+++ b/impl/src/main/resources/org/jboss/cdi/tck/tests/se/discovery/trimmed/beans.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd" version="2.0" bean-discovery-mode="all">
+	   xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd" version="3.0" bean-discovery-mode="all">
 	<trim/>
 </beans>

--- a/impl/src/main/resources/tck-audit-cdi.xml
+++ b/impl/src/main/resources/tck-audit-cdi.xml
@@ -8503,7 +8503,7 @@
                 |bean-discovery-mode| of |all|, or with no version number, or that is an empty file.
             </text>
             <assertion id="ba">
-                <text>Test an archive which contains a |beans.xml| file with a version number of 1.1, with the |bean-discovery-mode| of |all|.</text>
+                <text>Test an archive which contains a |beans.xml| file with a version number of 1.1 (or later), with the |bean-discovery-mode| of |all|.</text>
             </assertion>
             <assertion id="bb">
                 <text>Test an archive which contains a |beans.xml| file with no version number.</text>

--- a/impl/src/test/java/org/jboss/cdi/tck/test/shrinkwrap/AssetUtilTest.java
+++ b/impl/src/test/java/org/jboss/cdi/tck/test/shrinkwrap/AssetUtilTest.java
@@ -17,26 +17,35 @@
 package org.jboss.cdi.tck.test.shrinkwrap;
 
 import static org.testng.Assert.assertEquals;
-
-import java.io.File;
-import java.io.IOException;
+import static org.testng.Assert.assertTrue;
 
 import org.apache.commons.io.FileUtils;
 import org.jboss.cdi.tck.shrinkwrap.AssetUtil;
+import org.jboss.shrinkwrap.api.BeanDiscoveryMode;
+import org.jboss.shrinkwrap.api.BeansXmlVersion;
+import org.jboss.shrinkwrap.api.asset.Asset;
 import org.jboss.shrinkwrap.api.asset.ClassLoaderAsset;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
 
 public class AssetUtilTest {
 
     @Test
     public void testReadAssetContentAsString() throws IOException {
 
-        String content = Descriptors.create(BeansDescriptor.class).exportAsString();
-        StringAsset stringAsset = new StringAsset(content);
-        assertEquals(AssetUtil.readAssetContent(stringAsset).trim(), content.trim());
+        // TODO these are weak assertions because BeansXml cannot be translated to String easily
+        Asset asset = new BeansXml(BeanDiscoveryMode.ANNOTATED).alternatives(Engine.class).setBeansXmlVersion(BeansXmlVersion.v20);
+        String content = AssetUtil.readAssetContent(asset);
+        assertTrue(content != null);
+        assertTrue(content.length() > 0);
+        assertTrue(content.contains("bean-discovery-mode=\"annotated\""));
+        assertTrue(content.contains("version=\"2.0\""));
+        assertTrue(content.contains("<alternatives>"));
+        assertTrue(content.contains("<class>org.jboss.cdi.tck.test.shrinkwrap.Engine</class>"));
+        assertTrue(content.contains("</alternatives>"));
 
         ClassLoaderAsset classLoaderAsset = new ClassLoaderAsset("beans-01.xml");
         assertEquals(AssetUtil.readAssetContent(classLoaderAsset).trim().replaceAll("\\s", ""),

--- a/impl/src/test/java/org/jboss/cdi/tck/test/shrinkwrap/beansxml/BeansXmlTest.java
+++ b/impl/src/test/java/org/jboss/cdi/tck/test/shrinkwrap/beansxml/BeansXmlTest.java
@@ -1,0 +1,45 @@
+package org.jboss.cdi.tck.test.shrinkwrap.beansxml;
+
+import org.jboss.cdi.tck.shrinkwrap.AssetUtil;
+import org.jboss.shrinkwrap.api.BeanDiscoveryMode;
+import org.jboss.shrinkwrap.api.BeansXmlVersion;
+import org.jboss.shrinkwrap.impl.BeansXml;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * A very simple test that checks if {@link BeansXml} API constructs a valid descriptor with certain format.
+ * Note that {@link BeansXml} doesn't include XML namespace.
+ */
+public class BeansXmlTest {
+
+    // prepared String representation of expected outcome
+    private final String expectedBeansXmlFormat = "<beans version=\"1.1\" bean-discovery-mode=\"annotated\">\n" +
+            "<scan>\n" +
+            "<exclude name=\"org.jboss.cdi.tck.test.shrinkwrap.beansxml.*\" />\n" +
+            "</scan>\n" +
+            "<alternatives>\n" +
+            "<class>org.jboss.cdi.tck.test.shrinkwrap.beansxml.DummyReferenceClass</class>\n" +
+            "<stereotype>org.jboss.cdi.tck.test.shrinkwrap.beansxml.DummyReferenceClass</stereotype>\n" +
+            "</alternatives>\n" +
+            "<interceptors>\n" +
+            "<class>org.jboss.cdi.tck.test.shrinkwrap.beansxml.DummyReferenceClass</class>\n" +
+            "</interceptors>\n" +
+            "<decorators>\n" +
+            "<class>org.jboss.cdi.tck.test.shrinkwrap.beansxml.DummyReferenceClass</class>\n" +
+            "</decorators>\n" +
+            "</beans>\n";
+
+    @Test
+    public void testGeneratedBeansXml() {
+        BeansXml asset = new BeansXml(BeanDiscoveryMode.ANNOTATED)
+                .setBeansXmlVersion(BeansXmlVersion.v11)
+                .alternatives(DummyReferenceClass.class)
+                .stereotype(DummyReferenceClass.class)
+                .decorators(DummyReferenceClass.class)
+                .interceptors(DummyReferenceClass.class)
+                .excludeFilters(BeansXml.Exclude.match(BeansXmlTest.class.getPackage().getName() + ".*"));
+        String stringRepresentation = AssetUtil.readAssetContent(asset);
+        Assert.assertEquals(expectedBeansXmlFormat, stringRepresentation);
+    }
+}

--- a/impl/src/test/java/org/jboss/cdi/tck/test/shrinkwrap/beansxml/DummyReferenceClass.java
+++ b/impl/src/test/java/org/jboss/cdi/tck/test/shrinkwrap/beansxml/DummyReferenceClass.java
@@ -1,0 +1,4 @@
+package org.jboss.cdi.tck.test.shrinkwrap.beansxml;
+
+public class DummyReferenceClass {
+}

--- a/impl/src/test/resources/beans-01.xml
+++ b/impl/src/test/resources/beans-01.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" bean-discovery-mode="annotated" version="1.1">
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee" bean-discovery-mode="annotated" version="3.0">
     <alternatives>
         <class>org.jboss.cdi.tck.test.shrinkwrap.descriptors.Foo</class>
         <stereotype>org.jboss.cdi.tck.test.shrinkwrap.descriptors.Bar</stereotype>

--- a/impl/src/test/resources/beans-02.xml
+++ b/impl/src/test/resources/beans-02.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" bean-discovery-mode="annotated" version="1.1">
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee" bean-discovery-mode="annotated" version="3.0">
     <interceptors>
         <class>org.jboss.cdi.tck.test.shrinkwrap.descriptors.Bar</class>
         <class>org.jboss.cdi.tck.test.shrinkwrap.descriptors.Foo</class>

--- a/impl/src/test/resources/beans-03.xml
+++ b/impl/src/test/resources/beans-03.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" bean-discovery-mode="annotated" version="1.1">
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee" bean-discovery-mode="annotated" version="3.0">
     <decorators>
         <class>org.jboss.cdi.tck.test.shrinkwrap.descriptors.Bar</class>
         <class>org.jboss.cdi.tck.test.shrinkwrap.descriptors.Foo</class>

--- a/impl/src/test/resources/beans-04.xml
+++ b/impl/src/test/resources/beans-04.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" bean-discovery-mode="all" version="1.1"/>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee" bean-discovery-mode="all" version="3.0"/>

--- a/impl/src/test/resources/beans-05.xml
+++ b/impl/src/test/resources/beans-05.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" bean-discovery-mode="annotated" version="1.1">
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee" bean-discovery-mode="annotated" version="3.0">
     <scan>
         <exclude name="org.jboss.cdi.tck.*"/>
         <exclude name="org.jboss.cdi.tck.**">


### PR DESCRIPTION
Change tests to use this API instead of shrinkwrap descriptors where applicable.
Correct existing beans.xml files to use new namespaces and version 3.0.
Add a simple test of BeansXml API.

Fixes #222

This PR:
* Removes usage of Shrinkwrap descriptors for `beans.xml`
  * Note that we still use that for other descriptors which should be amended at some later point and the dependency could than be dropped
* Changes (hopefully) all `beans.xml` to use the new namespace and version
* Adds new `BeansXml` API that can construct a `beans.xml` asset which can be added into the constructed test archive

FTR I ran this version against latest Weld (on WildFly) to verify that it works.