### PR TITLE
Change JBoss repos to use https in order to work on Maven 3.8.1+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -431,7 +431,7 @@
                 <repository>
                     <id>jboss-public-repository-group</id>
                     <name>JBoss Public Maven Repository Group</name>
-                    <url>http://repository.jboss.org/nexus/content/groups/public</url>
+                    <url>https://repository.jboss.org/nexus/content/groups/public</url>
                     <releases>
                         <enabled>true</enabled>
                         <updatePolicy>never</updatePolicy>
@@ -446,7 +446,7 @@
                 <pluginRepository>
                     <id>jboss-public-repository-group</id>
                     <name>JBoss Public Maven Repository Group</name>
-                    <url>http://repository.jboss.org/nexus/content/groups/public</url>
+                    <url>https://repository.jboss.org/nexus/content/groups/public</url>
                     <releases>
                         <enabled>true</enabled>
                         <updatePolicy>never</updatePolicy>


### PR DESCRIPTION
Fix for #231 on top of TCKs for CDI 2.x (Jakarta EE 8).