### PR TITLE
Change development version to next major - 4.0.0-SNAPSHOT

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>jakarta.enterprise</groupId>
 		<artifactId>cdi-tck-parent</artifactId>
-		<version>3.0.3-SNAPSHOT</version>
+		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>cdi-tck-api</artifactId>

--- a/dist-build/libs/pom.xml
+++ b/dist-build/libs/pom.xml
@@ -3,13 +3,13 @@
     <parent>
         <groupId>jakarta.enterprise</groupId>
         <artifactId>cdi-tck-parent</artifactId>
-        <version>3.0.3-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <groupId>jakarta.enterprise</groupId>
     <artifactId>cdi-tck-dist-libs</artifactId>
-    <version>3.0.3-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>CDI TCK Distribution - Libraries</name>
 

--- a/dist-build/pom.xml
+++ b/dist-build/pom.xml
@@ -4,13 +4,13 @@
    <parent>
       <groupId>jakarta.enterprise</groupId>
       <artifactId>cdi-tck-parent</artifactId>
-      <version>3.0.3-SNAPSHOT</version>
+      <version>4.0.0-SNAPSHOT</version>
       <relativePath>../pom.xml</relativePath>
    </parent>
 
    <groupId>jakarta.enterprise</groupId>
    <artifactId>cdi-tck-dist</artifactId>
-   <version>3.0.3-SNAPSHOT</version>
+   <version>4.0.0-SNAPSHOT</version>
    <packaging>pom</packaging>
    <name>CDI TCK Distribution</name>
 

--- a/dist-build/porting-package/pom.xml
+++ b/dist-build/porting-package/pom.xml
@@ -4,13 +4,13 @@
     <parent>
         <groupId>jakarta.enterprise</groupId>
         <artifactId>cdi-tck-parent</artifactId>
-        <version>3.0.3-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <groupId>jakarta.enterprise</groupId>
     <artifactId>cdi-tck-dist-porting-package</artifactId>
-    <version>3.0.3-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>CDI TCK Distribution - Weld Porting Package</name>
 

--- a/doc/reference/pom.xml
+++ b/doc/reference/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>jakarta.enterprise</groupId>
         <artifactId>cdi-tck-parent</artifactId>
-        <version>3.0.3-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/ext-lib/pom.xml
+++ b/ext-lib/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cdi-tck-parent</artifactId>
         <groupId>jakarta.enterprise</groupId>
-        <version>3.0.3-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>cdi-tck-ext-lib</artifactId>
     <name>CDI TCK Installed Library - test bean archive</name>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cdi-tck-parent</artifactId>
         <groupId>jakarta.enterprise</groupId>
-        <version>3.0.3-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>cdi-tck-impl</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>jakarta.enterprise</groupId>
     <artifactId>cdi-tck-parent</artifactId>
     <packaging>pom</packaging>
-    <version>3.0.3-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
     <name>Jakarta CDI TCK</name>
 
     <parent>


### PR DESCRIPTION
The changes we are now adding to TCKs such as the API for programmatic beans.xml creation, or the split of TCKs into several parts will all belong to next major version. We should bump the version accordingly.

I have also created a `3.0` branch for any additional changes that would need to go into that version.