### PR TITLE
Update Arq. version to avoid using deprecated and removed CDI APIs.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
         <!-- Test tools/dependencies -->
         <testng.version>7.4.0</testng.version>
         <jboss.test.audit.version>2.0.0.Final</jboss.test.audit.version>
-        <arquillian.version>1.7.0.Alpha9</arquillian.version>
+        <arquillian.version>1.7.0.Alpha10</arquillian.version>
         <arquillian.container.se.api.version>1.0.1.Final</arquillian.container.se.api.version>
         <apache.httpclient.version>3.1</apache.httpclient.version>
         <htmlunit.version>2.50.0</htmlunit.version>


### PR DESCRIPTION
Use latest Arq. version in which there are no references to deprecated and now removed CDI API bits.

After merging this PR, I will do an Alpha 2 release in order to be able to consume a TCK artifact that is executable with latest CDI API.