### PR TITLE
Fix some failing test, remove several misplaced annotatation. Tests a…

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/BorderCollie.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/BorderCollie.java
@@ -16,9 +16,7 @@
  */
 package org.jboss.cdi.tck.tests.definition.scope;
 
-import jakarta.enterprise.context.Dependent;
-
-@Dependent
+@DummyStereotype
 public class BorderCollie extends Dog {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/Clydesdale.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/Clydesdale.java
@@ -16,9 +16,7 @@
  */
 package org.jboss.cdi.tck.tests.definition.scope;
 
-import jakarta.enterprise.context.Dependent;
-
-@Dependent
+@DummyStereotype
 public class Clydesdale extends Horse {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/DummyStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/DummyStereotype.java
@@ -1,0 +1,15 @@
+package org.jboss.cdi.tck.tests.definition.scope;
+
+import jakarta.enterprise.inject.Stereotype;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+// dummy stereotype just to have a bean defining annotation
+@Stereotype
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DummyStereotype {
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/EnglishBorderCollie.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/EnglishBorderCollie.java
@@ -16,9 +16,7 @@
  */
 package org.jboss.cdi.tck.tests.definition.scope;
 
-import jakarta.enterprise.context.Dependent;
-
-@Dependent
+@DummyStereotype
 public class EnglishBorderCollie extends BorderCollie {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/GoldenLabrador.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/GoldenLabrador.java
@@ -16,9 +16,7 @@
  */
 package org.jboss.cdi.tck.tests.definition.scope;
 
-import jakarta.enterprise.context.Dependent;
-
-@Dependent
+@DummyStereotype
 public class GoldenLabrador extends Labrador {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/GoldenRetriever.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/GoldenRetriever.java
@@ -16,9 +16,7 @@
  */
 package org.jboss.cdi.tck.tests.definition.scope;
 
-import jakarta.enterprise.context.Dependent;
-
-@Dependent
+@DummyStereotype
 public class GoldenRetriever extends Retriever {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/MiniatureClydesdale.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/MiniatureClydesdale.java
@@ -16,9 +16,7 @@
  */
 package org.jboss.cdi.tck.tests.definition.scope;
 
-import jakarta.enterprise.context.Dependent;
-
-@Dependent
+@DummyStereotype
 public class MiniatureClydesdale extends Clydesdale {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/Order.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/Order.java
@@ -16,9 +16,7 @@
  */
 package org.jboss.cdi.tck.tests.definition.scope;
 
-import jakarta.enterprise.context.Dependent;
-
-@Dependent
+@DummyStereotype
 public class Order {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/ShetlandPony.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/ShetlandPony.java
@@ -16,9 +16,7 @@
  */
 package org.jboss.cdi.tck.tests.definition.scope;
 
-import jakarta.enterprise.context.Dependent;
-
-@Dependent
+@DummyStereotype
 public class ShetlandPony extends Horse {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/BorderCollie.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/BorderCollie.java
@@ -16,9 +16,6 @@
  */
 package org.jboss.cdi.tck.tests.definition.stereotype;
 
-import jakarta.enterprise.context.Dependent;
-
-@Dependent
 public class BorderCollie extends LongHairedDog {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/Chihuahua.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/Chihuahua.java
@@ -16,9 +16,6 @@
  */
 package org.jboss.cdi.tck.tests.definition.stereotype;
 
-import jakarta.enterprise.context.Dependent;
-
-@Dependent
 public class Chihuahua extends ShortHairedDog {
 
     /**

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/Clydesdale.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/Clydesdale.java
@@ -16,9 +16,6 @@
  */
 package org.jboss.cdi.tck.tests.definition.stereotype;
 
-import jakarta.enterprise.context.Dependent;
-
-@Dependent
 public class Clydesdale extends Horse {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/DummyStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/DummyStereotype.java
@@ -1,0 +1,16 @@
+package org.jboss.cdi.tck.tests.definition.stereotype;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import jakarta.enterprise.inject.Stereotype;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+// empty stereotype just to trigger bean discovery
+@Stereotype
+@Target(TYPE)
+@Retention(RUNTIME)
+public @interface DummyStereotype {
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/EnglishBorderCollie.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/EnglishBorderCollie.java
@@ -16,9 +16,6 @@
  */
 package org.jboss.cdi.tck.tests.definition.stereotype;
 
-import jakarta.enterprise.context.Dependent;
-
-@Dependent
 public class EnglishBorderCollie extends BorderCollie {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/Horse.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/Horse.java
@@ -16,10 +16,7 @@
  */
 package org.jboss.cdi.tck.tests.definition.stereotype;
 
-import jakarta.enterprise.context.Dependent;
-
 @AnotherStereotype
-@Dependent
 public class Horse {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/LongHairedDog.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/LongHairedDog.java
@@ -16,10 +16,7 @@
  */
 package org.jboss.cdi.tck.tests.definition.stereotype;
 
-import jakarta.enterprise.context.Dependent;
-
 @AnimalStereotype
-@Dependent
 public class LongHairedDog implements Animal {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/MexicanChihuahua.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/MexicanChihuahua.java
@@ -16,9 +16,6 @@
  */
 package org.jboss.cdi.tck.tests.definition.stereotype;
 
-import jakarta.enterprise.context.Dependent;
-
-@Dependent
 public class MexicanChihuahua extends Chihuahua {
 
     /**

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/MiniatureClydesdale.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/MiniatureClydesdale.java
@@ -16,9 +16,7 @@
  */
 package org.jboss.cdi.tck.tests.definition.stereotype;
 
-import jakarta.enterprise.context.Dependent;
-
-@Dependent
+@DummyStereotype
 public class MiniatureClydesdale extends Clydesdale {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/Moose.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/Moose.java
@@ -16,10 +16,7 @@
  */
 package org.jboss.cdi.tck.tests.definition.stereotype;
 
-import jakarta.enterprise.context.Dependent;
-
 @AnimalStereotype
-@Dependent
 public class Moose implements Animal {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/Reindeer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/Reindeer.java
@@ -16,10 +16,7 @@
  */
 package org.jboss.cdi.tck.tests.definition.stereotype;
 
-import jakarta.enterprise.context.Dependent;
-
 @HornedMammalStereotype
-@Dependent
 public class Reindeer implements Animal {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/ShetlandPony.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/ShetlandPony.java
@@ -16,9 +16,7 @@
  */
 package org.jboss.cdi.tck.tests.definition.stereotype;
 
-import jakarta.enterprise.context.Dependent;
-
-@Dependent
+@DummyStereotype
 public class ShetlandPony extends Horse {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/parameterized/IntegerListObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/parameterized/IntegerListObserver.java
@@ -18,8 +18,8 @@ package org.jboss.cdi.tck.tests.event.parameterized;
 
 import java.util.List;
 
-import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.context.ApplicationScoped;
 
-@Dependent
+@ApplicationScoped
 public class IntegerListObserver extends AbstractParameterizedObserver<List<Integer>> {
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/parameterized/StringListObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/parameterized/StringListObserver.java
@@ -18,8 +18,8 @@ package org.jboss.cdi.tck.tests.event.parameterized;
 
 import java.util.List;
 
-import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.context.ApplicationScoped;
 
-@Dependent
+@ApplicationScoped
 public class StringListObserver extends AbstractParameterizedObserver<List<String>> {
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/communication/EventBase.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/communication/EventBase.java
@@ -17,13 +17,10 @@
 
 package org.jboss.cdi.tck.tests.extensions.communication;
 
-import jakarta.enterprise.context.Dependent;
-
 /**
  * @author Martin Kouba
  * 
  */
-@Dependent
 public abstract class EventBase {
 
     public static final String PAT_SEQ = "pat";

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/communication/ExtensionsCommunicationTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/communication/ExtensionsCommunicationTest.java
@@ -53,9 +53,7 @@ public class ExtensionsCommunicationTest extends AbstractTest {
         // Fired by alpha, recorder by beta
         ActionSequence patSeq = ActionSequence.getSequence(EventBase.PAT_SEQ);
         assertNotNull(patSeq);
-        patSeq.assertDataContainsAll(Foo.class.getName(), Bar.class.getName(), EventBase.class.getName(),
-                PatEvent.class.getName(), PbEvent.class.getName(), ExtensionAlpha.class.getName(),
-                ExtensionBeta.class.getName());
+        patSeq.assertDataContainsAll(Foo.class.getName(), Bar.class.getName(), PatEvent.class.getName());
 
         // Fired by beta, recorder by alpha
         ActionSequence pbSeq = ActionSequence.getSequence(EventBase.PB_SEQ);

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/communication/PatEvent.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/communication/PatEvent.java
@@ -23,6 +23,7 @@ import jakarta.enterprise.context.Dependent;
  * @author Martin Kouba
  * 
  */
+// deliberately annotated so that it triggers PAT in extension processing
 @Dependent
 public class PatEvent extends EventBase {
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/communication/PbEvent.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/communication/PbEvent.java
@@ -17,13 +17,10 @@
 
 package org.jboss.cdi.tck.tests.extensions.communication;
 
-import jakarta.enterprise.context.Dependent;
-
 /**
  * @author Martin Kouba
  * 
  */
-@Dependent
 public class PbEvent extends EventBase {
 
     /**

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/configurators/annotatedTypeConfigurator/AnnotatedTypeConfiguratorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/configurators/annotatedTypeConfigurator/AnnotatedTypeConfiguratorTest.java
@@ -48,7 +48,9 @@ import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.literals.DisposesLiteral;
 import org.jboss.cdi.tck.literals.ProducesLiteral;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
+import org.jboss.shrinkwrap.api.BeanDiscoveryMode;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
@@ -70,7 +72,7 @@ public class AnnotatedTypeConfiguratorTest extends AbstractTest {
         return new WebArchiveBuilder().withTestClassPackage(AnnotatedTypeConfiguratorTest.class)
                 .withClasses(ProducesLiteral.class, DisposesLiteral.class)
                 .withExtensions(ProcessAnnotatedTypeObserver.class
-                ).build();
+                ).withBeansXml(new BeansXml(BeanDiscoveryMode.ALL)).build();
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/configurators/annotatedTypeConfigurator/Cats.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/configurators/annotatedTypeConfigurator/Cats.java
@@ -21,7 +21,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
@@ -30,7 +29,6 @@ import jakarta.inject.Qualifier;
 @Target({ ElementType.FIELD, ElementType.METHOD, ElementType.TYPE, ElementType.PARAMETER })
 public @interface Cats {
 
-    @Dependent
     public static class CatsLiteral extends AnnotationLiteral<Cats> implements Cats {
             public static CatsLiteral INSTANCE = new CatsLiteral();
     }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/configurators/annotatedTypeConfigurator/Dog.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/configurators/annotatedTypeConfigurator/Dog.java
@@ -16,9 +16,6 @@
  */
 package org.jboss.cdi.tck.tests.extensions.configurators.annotatedTypeConfigurator;
 
-import jakarta.enterprise.context.Dependent;
-
-//@Dependent
 public class Dog {
 
     private Feed feed;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/configurators/annotatedTypeConfigurator/Dogs.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/configurators/annotatedTypeConfigurator/Dogs.java
@@ -21,7 +21,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
@@ -30,7 +29,6 @@ import jakarta.inject.Qualifier;
 @Target({ ElementType.FIELD, ElementType.METHOD, ElementType.TYPE })
 public @interface Dogs {
 
-    @Dependent
     public static class DogsLiteral extends AnnotationLiteral<Dogs> implements Dogs {
 
         public static DogsLiteral INSTANCE = new DogsLiteral();

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/configurators/annotatedTypeConfigurator/Feed.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/configurators/annotatedTypeConfigurator/Feed.java
@@ -16,8 +16,5 @@
  */
 package org.jboss.cdi.tck.tests.extensions.configurators.annotatedTypeConfigurator;
 
-import jakarta.enterprise.context.Dependent;
-
-@Dependent
 public class Feed {
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/configurators/annotatedTypeConfigurator/Room.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/configurators/annotatedTypeConfigurator/Room.java
@@ -16,8 +16,5 @@
  */
 package org.jboss.cdi.tck.tests.extensions.configurators.annotatedTypeConfigurator;
 
-import jakarta.enterprise.context.Dependent;
-
-@Dependent
 public class Room {
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/configurators/annotatedTypeConfigurator/Wild.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/configurators/annotatedTypeConfigurator/Wild.java
@@ -21,7 +21,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
@@ -30,7 +29,6 @@ import jakarta.inject.Qualifier;
 @Target({ ElementType.FIELD, ElementType.METHOD, ElementType.TYPE })
 public @interface Wild {
 
-    @Dependent
     public static class WildLiteral extends AnnotationLiteral<Wild> implements Wild {
 
         public static WildLiteral INSTANCE = new WildLiteral();

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/atd/DeltaAlternativeBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/atd/DeltaAlternativeBean.java
@@ -30,7 +30,6 @@ import java.util.Set;
 import jakarta.enterprise.inject.Default;
 import jakarta.enterprise.inject.spi.Prioritized;
 
-@Dependent
 public class DeltaAlternativeBean implements Bean<DeltaAlternative>, Prioritized {
 
     public Class<?> getBeanClass() {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/atd/DeltaDecoratorBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/atd/DeltaDecoratorBean.java
@@ -28,7 +28,6 @@ import java.util.Set;
 
 import jakarta.enterprise.inject.Default;
 
-@Dependent
 public class DeltaDecoratorBean implements Decorator<DeltaDecorator>, Prioritized {
 
     private AnnotatedField<? super DeltaDecorator> annotatedField = null;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/atd/DeltaInterceptorBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/atd/DeltaInterceptorBean.java
@@ -28,7 +28,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-@Dependent
 public class DeltaInterceptorBean implements Interceptor<DeltaInterceptor> {
 
     public Set<Annotation> getInterceptorBindings() {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/atd/EchoAlternative.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/atd/EchoAlternative.java
@@ -17,6 +17,7 @@
 package org.jboss.cdi.tck.tests.extensions.lifecycle.atd;
 
 import jakarta.annotation.Priority;
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Alternative;
 
 /**
@@ -25,6 +26,7 @@ import jakarta.enterprise.inject.Alternative;
  */
 @Alternative
 @Priority(2600)
+@Dependent
 public class EchoAlternative implements Alternatives {
     
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/atd/lib/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/atd/lib/Bar.java
@@ -16,9 +16,6 @@
  */
 package org.jboss.cdi.tck.tests.extensions.lifecycle.atd.lib;
 
-import jakarta.enterprise.context.Dependent;
-
-@Dependent
 public class Bar {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/atd/lib/Baz.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/atd/lib/Baz.java
@@ -16,10 +16,8 @@
  */
 package org.jboss.cdi.tck.tests.extensions.lifecycle.atd.lib;
 
-import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Instance;
 
-@Dependent
 public class Baz {
 
     Instance<Bar> barInstance;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/atd/lib/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/atd/lib/Foo.java
@@ -16,9 +16,6 @@
  */
 package org.jboss.cdi.tck.tests.extensions.lifecycle.atd.lib;
 
-import jakarta.enterprise.context.Dependent;
-
-@Dependent
 public class Foo {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/bbd/BeforeBeanDiscoveryTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/bbd/BeforeBeanDiscoveryTest.java
@@ -35,7 +35,9 @@ import org.jboss.cdi.tck.tests.extensions.lifecycle.bbd.lib.Baz;
 import org.jboss.cdi.tck.tests.extensions.lifecycle.bbd.lib.Boss;
 import org.jboss.cdi.tck.tests.extensions.lifecycle.bbd.lib.Foo;
 import org.jboss.cdi.tck.tests.extensions.lifecycle.bbd.lib.Pro;
+import org.jboss.shrinkwrap.api.BeanDiscoveryMode;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
@@ -54,6 +56,7 @@ public class BeforeBeanDiscoveryTest extends AbstractTest {
         return new WebArchiveBuilder().withTestClassPackage(BeforeBeanDiscoveryTest.class)
                 .withExtension(BeforeBeanDiscoveryObserver.class)
                 .withLibrary(Boss.class, Foo.class, Bar.class, Baz.class, Pro.class)
+                .withBeansXml(new BeansXml(BeanDiscoveryMode.ALL))
                 .build();
     }
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/bbd/lib/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/bbd/lib/Bar.java
@@ -16,9 +16,6 @@
  */
 package org.jboss.cdi.tck.tests.extensions.lifecycle.bbd.lib;
 
-import jakarta.enterprise.context.Dependent;
-
-@Dependent
 public class Bar {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/bbd/lib/Baz.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/bbd/lib/Baz.java
@@ -16,10 +16,8 @@
  */
 package org.jboss.cdi.tck.tests.extensions.lifecycle.bbd.lib;
 
-import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Instance;
 
-@Dependent
 public class Baz {
 
     Instance<Bar> barInstance;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/bbd/lib/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/bbd/lib/Foo.java
@@ -16,9 +16,6 @@
  */
 package org.jboss.cdi.tck.tests.extensions.lifecycle.bbd.lib;
 
-import jakarta.enterprise.context.Dependent;
-
-@Dependent
 public class Foo {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processBeanAttributes/modify/Cat.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processBeanAttributes/modify/Cat.java
@@ -16,8 +16,5 @@
  */
 package org.jboss.cdi.tck.tests.extensions.lifecycle.processBeanAttributes.modify;
 
-import jakarta.enterprise.context.Dependent;
-
-@Dependent
 public class Cat implements Animal {
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processBeanAttributes/modify/SetBeanAttributesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processBeanAttributes/modify/SetBeanAttributesTest.java
@@ -30,6 +30,7 @@ import jakarta.inject.Inject;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
+import org.jboss.shrinkwrap.api.BeanDiscoveryMode;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
@@ -54,7 +55,7 @@ public class SetBeanAttributesTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder().withTestClassPackage(SetBeanAttributesTest.class)
                 .withExtension(ModifyingExtension.class)
-                .withBeansXml(new BeansXml().alternatives(Cat.class))
+                .withBeansXml(new BeansXml(BeanDiscoveryMode.ALL).alternatives(Cat.class))
                 .build();
     }
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/qualifiers/Mock.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/qualifiers/Mock.java
@@ -25,7 +25,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
@@ -35,7 +34,6 @@ import jakarta.inject.Qualifier;
 public @interface Mock {
 
     @SuppressWarnings("all")
-    @Dependent
     public static class MockLiteral extends AnnotationLiteral<Mock> implements Mock {
 
         public MockLiteral() {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/qualifiers/StaticNestedClassesParent.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/qualifiers/StaticNestedClassesParent.java
@@ -19,14 +19,15 @@ package org.jboss.cdi.tck.tests.inheritance.specialization.qualifiers;
 import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Specializes;
 
-@Dependent
 public class StaticNestedClassesParent {
     @Mock
+    @Dependent
     public static class StaticSpecializationBean {
 
     }
 
     @Specializes
+    @Dependent
     public static class StaticMockSpecializationBean extends StaticSpecializationBean {
 
     }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/finalMethod/ExtendedTuna_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/finalMethod/ExtendedTuna_Broken.java
@@ -16,8 +16,8 @@
  */
 package org.jboss.cdi.tck.tests.lookup.clientProxy.unproxyable.finalMethod;
 
-import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.context.RequestScoped;
 
-@Dependent
+@RequestScoped
 public class ExtendedTuna_Broken extends Tuna_Broken {
 }


### PR DESCRIPTION
…sserting on portable extensions can explicitly declare ALL discovery mode.

This is a follow up on Scott's PR - https://github.com/eclipse-ee4j/cdi-tck/pull/256 (which is issue https://github.com/eclipse-ee4j/cdi-tck/issues/255)
I was asked to look at the remaining non-container tests that fail so this PR contains fixes for them.

With these changes, I am getting 0 fails on Weld:
> [INFO] Results:
[INFO] 
[INFO] Tests run: 1195, Failures: 0, Errors: 0, Skipped: 0