### PR TITLE
Introduce a test for archive with empty beans.xml that doesn't rely o…

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/BeanDiscoveryTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/BeanDiscoveryTest.java
@@ -123,7 +123,7 @@ public class BeanDiscoveryTest extends AbstractTest {
     @Test(dataProvider = ARQUILLIAN_DATA_PROVIDER)
     @SpecAssertions({ @SpecAssertion(section = BEAN_ARCHIVE, id = "bb"), @SpecAssertion(section = BEAN_ARCHIVE, id = "bc"),
             @SpecAssertion(section = TYPE_DISCOVERY_STEPS, id = "a") })
-    public void testExplicitBeanArchiveEmptyDescriptor(Bravo bravo) {
+    public void testImplicitBeanArchiveEmptyDescriptor(Bravo bravo) {
         assertDiscoveredAndAvailable(bravo, Bravo.class);
     }
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/BravoUnannotated.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/BravoUnannotated.java
@@ -1,0 +1,9 @@
+package org.jboss.cdi.tck.tests.deployment.discovery;
+
+// no bean defining annotation
+public class BravoUnannotated implements Ping{
+
+    @Override
+    public void pong() {
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/EmptyBeansXmlDiscoveryTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/EmptyBeansXmlDiscoveryTest.java
@@ -1,0 +1,35 @@
+package org.jboss.cdi.tck.tests.deployment.discovery;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.spi.CDI;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.cdi.tck.AbstractTest;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
+
+/**
+ * Tests that a singular archive with empty beans.xml results in annotated discovery mode.
+ */
+public class EmptyBeansXmlDiscoveryTest extends AbstractTest {
+
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return ShrinkWrap.create(WebArchive.class).addClasses(Bravo.class, BravoUnannotated.class)
+                .addAsWebInfResource(new StringAsset(""), "beans.xml");
+    }
+
+    @Test(dataProvider = ARQUILLIAN_DATA_PROVIDER)
+    public void testBeanArchiveWithEmptyBeansXml() {
+        Instance<Object> instance = CDI.current().getBeanContainer().createInstance();
+        Instance<Bravo> bravoInstance = instance.select(Bravo.class);
+        assertTrue(bravoInstance.isResolvable());
+        bravoInstance.get().pong();
+        Instance<BravoUnannotated> bravoUnannotatedInstance = instance.select(BravoUnannotated.class);
+        assertFalse(bravoUnannotatedInstance.isResolvable());
+    }
+}


### PR DESCRIPTION
…n portable extension for verification.

Fixes #260 