### PR TITLE
Change the TCK SE tests to work correctly after empty beans.xml discovery mode change

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/Baz.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/Baz.java
@@ -16,8 +16,10 @@
  */
 package org.jboss.cdi.tck.tests.se.container;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 
+@Dependent
 public class Baz {
 
     @Inject

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/BazObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/BazObserver.java
@@ -16,8 +16,10 @@
  */
 package org.jboss.cdi.tck.tests.se.container;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Observes;
 
+@Dependent
 public class BazObserver {
 
     public static boolean isNotified = false;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/Circle.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/Circle.java
@@ -16,9 +16,11 @@
  */
 package org.jboss.cdi.tck.tests.se.container;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Alternative;
 
 @Alternative
+@Dependent
 public class Circle implements Shape {
 
     public static String NAME = "Circle";

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/Qux.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/Qux.java
@@ -16,5 +16,8 @@
  */
 package org.jboss.cdi.tck.tests.se.container;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class Qux {
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/Square.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/Square.java
@@ -16,6 +16,9 @@
  */
 package org.jboss.cdi.tck.tests.se.container;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class Square implements Shape {
     public static String NAME = "Square";
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/customClassloader/Alpha.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/customClassloader/Alpha.java
@@ -16,6 +16,9 @@
  */
 package org.jboss.cdi.tck.tests.se.container.customClassloader;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class Alpha {
 
     public void ping() {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/customClassloader/Bravo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/customClassloader/Bravo.java
@@ -16,6 +16,9 @@
  */
 package org.jboss.cdi.tck.tests.se.container.customClassloader;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class Bravo {
 
     public void ping() {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/testPackage/Worm.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/testPackage/Worm.java
@@ -16,5 +16,8 @@
  */
 package org.jboss.cdi.tck.tests.se.container.testPackage;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class Worm {
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/testPackage/nestedPackage/Pear.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/testPackage/nestedPackage/Pear.java
@@ -16,5 +16,8 @@
  */
 package org.jboss.cdi.tck.tests.se.container.testPackage.nestedPackage;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class Pear {
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/ApplicationScopedObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/ApplicationScopedObserver.java
@@ -18,10 +18,12 @@ package org.jboss.cdi.tck.tests.se.context;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.BeforeDestroyed;
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.context.Destroyed;
 import jakarta.enterprise.context.Initialized;
 import jakarta.enterprise.event.Observes;
 
+@Dependent
 public class ApplicationScopedObserver {
 
     public static boolean isInitialized;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/Bar.java
@@ -16,8 +16,10 @@
  */
 package org.jboss.cdi.tck.tests.se.context;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 
+@Dependent
 public class Bar {
 
     @Inject

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/Baz.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/Baz.java
@@ -16,8 +16,10 @@
  */
 package org.jboss.cdi.tck.tests.se.context;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 
+@Dependent
 public class Baz {
 
     @Inject

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/Foo.java
@@ -16,8 +16,10 @@
  */
 package org.jboss.cdi.tck.tests.se.context;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 
+@Dependent
 public class Foo {
     
     @Inject

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/activation/interceptor/ClassInterceptorContextActivator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/activation/interceptor/ClassInterceptorContextActivator.java
@@ -16,12 +16,14 @@
  */
 package org.jboss.cdi.tck.tests.se.context.activation.interceptor;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.context.control.ActivateRequestContext;
 import jakarta.inject.Inject;
 
 @BeforeActivationBinding
 @ActivateRequestContext
 @AfterActivationBinding
+@Dependent
 public class ClassInterceptorContextActivator {
 
     @Inject

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/activation/interceptor/MethodInterceptorContextActivator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/activation/interceptor/MethodInterceptorContextActivator.java
@@ -16,9 +16,11 @@
  */
 package org.jboss.cdi.tck.tests.se.context.activation.interceptor;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.context.control.ActivateRequestContext;
 import jakarta.inject.Inject;
 
+@Dependent
 public class MethodInterceptorContextActivator {
 
     @Inject


### PR DESCRIPTION
Related to #273 

This PR fixes TCK SE tests to work after beans.xml changes:

```
[INFO] Tests run: 33, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 29.562 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 33, Failures: 0, Errors: 0, Skipped: 0
```