### PR TITLE
Address missing bean defining annotations, part 1.

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/Bar.java
@@ -17,9 +17,13 @@
 
 package org.jboss.cdi.tck.tests.alternative.resolution.qualifier;
 
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Alternative;
 
 @Alternative
+@Priority(1)
+@Dependent
 public class Bar implements Foo {
 
     @Override

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/Baz.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/Baz.java
@@ -17,7 +17,10 @@
 
 package org.jboss.cdi.tck.tests.alternative.resolution.qualifier;
 
+import jakarta.enterprise.context.Dependent;
+
 @True
+@Dependent
 public class Baz implements Foo {
 
     @Override

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/Dungeon.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/Dungeon.java
@@ -17,8 +17,10 @@
 
 package org.jboss.cdi.tck.tests.alternative.resolution.qualifier;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 
+@Dependent
 public class Dungeon {
 
     @False

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/Foo.java
@@ -17,6 +17,9 @@
 
 package org.jboss.cdi.tck.tests.alternative.resolution.qualifier;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public interface Foo {
 
     public int ping();

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/Forest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/Forest.java
@@ -17,8 +17,10 @@
 
 package org.jboss.cdi.tck.tests.alternative.resolution.qualifier;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 
+@Dependent
 public class Forest {
 
     @True

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/Larch.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/Larch.java
@@ -17,9 +17,13 @@
 
 package org.jboss.cdi.tck.tests.alternative.resolution.qualifier;
 
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Alternative;
 
 @Alternative
+@Priority(1)
+@Dependent
 public class Larch extends Tree {
 
     public int ping() {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/Monster.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/Monster.java
@@ -17,7 +17,10 @@
 
 package org.jboss.cdi.tck.tests.alternative.resolution.qualifier;
 
+import jakarta.enterprise.context.Dependent;
+
 @False
+@Dependent
 public class Monster {
 
     public int ping() {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/QualifierInheritedTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/QualifierInheritedTest.java
@@ -47,7 +47,6 @@ public class QualifierInheritedTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder().withTestClass(QualifierInheritedTest.class)
                 .withClasses(Tree.class, Larch.class, Forest.class, True.class, TrueLiteral.class)
-                .withBeansXml(new BeansXml().alternatives(Larch.class))
                 .build();
     }
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/QualifierNotDeclaredTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/QualifierNotDeclaredTest.java
@@ -44,7 +44,6 @@ public class QualifierNotDeclaredTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder().withTestClass(QualifierNotDeclaredTest.class)
                 .withClasses(Foo.class, Bar.class, Baz.class, Qux.class, True.class, TrueLiteral.class)
-                .withBeansXml(new BeansXml().alternatives(Bar.class))
                 .build();
     }
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/QualifierNotInheritedTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/QualifierNotInheritedTest.java
@@ -47,7 +47,6 @@ public class QualifierNotInheritedTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder().withTestClass(QualifierNotInheritedTest.class)
                 .withClasses(Monster.class, Troll.class, Dungeon.class, False.class, FalseLiteral.class)
-                .withBeansXml(new BeansXml().alternatives(Troll.class))
                 .build();
     }
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/Qux.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/Qux.java
@@ -17,8 +17,10 @@
 
 package org.jboss.cdi.tck.tests.alternative.resolution.qualifier;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 
+@Dependent
 public class Qux {
 
     @Inject

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/Tree.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/Tree.java
@@ -17,7 +17,10 @@
 
 package org.jboss.cdi.tck.tests.alternative.resolution.qualifier;
 
+import jakarta.enterprise.context.Dependent;
+
 @True
+@Dependent
 public class Tree {
 
     public int ping() {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/Troll.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/Troll.java
@@ -17,9 +17,13 @@
 
 package org.jboss.cdi.tck.tests.alternative.resolution.qualifier;
 
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Alternative;
 
 @Alternative
+@Priority(1)
+@Dependent
 public class Troll extends Monster {
 
     public int ping() {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/Alpha.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/Alpha.java
@@ -17,6 +17,9 @@
 
 package org.jboss.cdi.tck.tests.alternative.selection;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class Alpha extends AssertBean {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/Bar.java
@@ -18,10 +18,12 @@
 package org.jboss.cdi.tck.tests.alternative.selection;
 
 import jakarta.annotation.Priority;
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Alternative;
 
 @Priority(2000)
 @Alternative
+@Dependent
 public class Bar implements TestBean {
 
     @Override

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/BarProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/BarProducer.java
@@ -18,10 +18,12 @@
 package org.jboss.cdi.tck.tests.alternative.selection;
 
 import jakarta.annotation.Priority;
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Alternative;
 import jakarta.enterprise.inject.Produces;
 
 @Priority(1100)
+@Dependent
 public class BarProducer {
 
     @Alternative

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/Boss.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/Boss.java
@@ -17,11 +17,13 @@
 package org.jboss.cdi.tck.tests.alternative.selection;
 
 import jakarta.annotation.Priority;
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Alternative;
 import jakarta.enterprise.inject.Produces;
 
 @Priority(900)
 @Alternative
+@Dependent
 public class Boss {
 
     @Produces

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/Bravo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/Bravo.java
@@ -17,6 +17,9 @@
 
 package org.jboss.cdi.tck.tests.alternative.selection;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class Bravo extends AssertBean {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/Charlie.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/Charlie.java
@@ -17,6 +17,9 @@
 
 package org.jboss.cdi.tck.tests.alternative.selection;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class Charlie extends AssertBean {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/Foo.java
@@ -18,10 +18,12 @@
 package org.jboss.cdi.tck.tests.alternative.selection;
 
 import jakarta.annotation.Priority;
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Alternative;
 
 @Priority(1000)
 @Alternative
+@Dependent
 public class Foo implements TestBean {
 
     @Override

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/FooProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/FooProducer.java
@@ -17,11 +17,11 @@
 
 package org.jboss.cdi.tck.tests.alternative.selection;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Alternative;
 import jakarta.enterprise.inject.Produces;
 
-import org.jboss.cdi.tck.tests.alternative.Wild;
-
+@Dependent
 public class FooProducer {
 
     @Alternative

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/instance/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/instance/Foo.java
@@ -20,8 +20,10 @@ package org.jboss.cdi.tck.tests.context.dependent.instance;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 
+import jakarta.enterprise.context.Dependent;
 import org.jboss.cdi.tck.util.SimpleLogger;
 
+@Dependent
 public class Foo {
 
     private static final SimpleLogger logger = new SimpleLogger(Foo.class);

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/transientreference/Spoon.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/transientreference/Spoon.java
@@ -16,10 +16,12 @@
  */
 package org.jboss.cdi.tck.tests.context.dependent.transientreference;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.TransientReference;
 import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.inject.Inject;
 
+@Dependent
 public class Spoon {
 
     @Inject

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/DependentFinalTuna.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/DependentFinalTuna.java
@@ -16,6 +16,9 @@
  */
 package org.jboss.cdi.tck.tests.definition.bean;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 final class DependentFinalTuna {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/FriendlyAntelope.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/FriendlyAntelope.java
@@ -16,6 +16,9 @@
  */
 package org.jboss.cdi.tck.tests.definition.bean;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class FriendlyAntelope extends AbstractAntelope {
     @Override
     public String getGreeting() {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/Horse.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/Horse.java
@@ -16,10 +16,13 @@
  */
 package org.jboss.cdi.tck.tests.definition.bean;
 
+import jakarta.enterprise.context.Dependent;
+
 /**
  * @author pmuir
  * 
  */
+@Dependent
 public class Horse {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/MyBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/MyBean.java
@@ -16,5 +16,8 @@
  */
 package org.jboss.cdi.tck.tests.definition.bean;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 class MyBean<T> implements MyInterface {
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/MyGenericBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/MyGenericBean.java
@@ -16,5 +16,8 @@
  */
 package org.jboss.cdi.tck.tests.definition.bean;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 class MyGenericBean<T> extends MyBean<T> {
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/MyRawBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/MyRawBean.java
@@ -16,6 +16,9 @@
  */
 package org.jboss.cdi.tck.tests.definition.bean;
 
+import jakarta.enterprise.context.Dependent;
+
 @SuppressWarnings("rawtypes")
+@Dependent
 class MyRawBean extends MyBean {
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/Spider.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/Spider.java
@@ -16,6 +16,9 @@
  */
 package org.jboss.cdi.tck.tests.definition.bean;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class Spider implements Animal {
 
     public final void layEggs() {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/SpiderProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/SpiderProducer.java
@@ -16,8 +16,10 @@
  */
 package org.jboss.cdi.tck.tests.definition.bean;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
 
+@Dependent
 public class SpiderProducer {
 
     @Produces

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/Tarantula.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/Tarantula.java
@@ -16,6 +16,9 @@
  */
 package org.jboss.cdi.tck.tests.definition.bean;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 final class Tarantula extends Spider implements DeadlySpider {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/WolfSpider.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/WolfSpider.java
@@ -16,6 +16,9 @@
  */
 package org.jboss.cdi.tck.tests.definition.bean;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class WolfSpider implements Animal {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/broken/restricted/Animal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/broken/restricted/Animal.java
@@ -16,10 +16,13 @@
  */
 package org.jboss.cdi.tck.tests.definition.bean.broken.restricted;
 
+import jakarta.enterprise.context.Dependent;
+
 /**
  * 
  * @author Martin Kouba
  */
+@Dependent
 public class Animal {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/broken/restricted/BoulderFieldProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/broken/restricted/BoulderFieldProducer.java
@@ -16,6 +16,7 @@
  */
 package org.jboss.cdi.tck.tests.definition.bean.broken.restricted;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
 import jakarta.enterprise.inject.Typed;
 
@@ -23,6 +24,7 @@ import jakarta.enterprise.inject.Typed;
  * 
  * @author Martin Kouba
  */
+@Dependent
 public class BoulderFieldProducer {
 
     @Typed(Animal.class)

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/broken/restricted/BoulderMethodProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/broken/restricted/BoulderMethodProducer.java
@@ -16,6 +16,7 @@
  */
 package org.jboss.cdi.tck.tests.definition.bean.broken.restricted;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
 import jakarta.enterprise.inject.Typed;
 
@@ -23,6 +24,7 @@ import jakarta.enterprise.inject.Typed;
  * 
  * @author Martin Kouba
  */
+@Dependent
 public class BoulderMethodProducer {
 
     @Typed(Animal.class)

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/broken/restricted/Stone.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/broken/restricted/Stone.java
@@ -16,12 +16,14 @@
  */
 package org.jboss.cdi.tck.tests.definition.bean.broken.restricted;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Typed;
 
 /**
  * 
  * @author Martin Kouba
  */
+@Dependent
 @Typed(value = Animal.class)
 public class Stone {
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/Flock.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/Flock.java
@@ -17,11 +17,14 @@
 
 package org.jboss.cdi.tck.tests.definition.bean.types;
 
+import jakarta.enterprise.context.Dependent;
+
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 
+@Dependent
 public class Flock implements List<Vulture<Integer>> {
 
     @Override

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/GriffonVulture.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/GriffonVulture.java
@@ -17,6 +17,9 @@
 
 package org.jboss.cdi.tck.tests.definition.bean.types;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class GriffonVulture extends Vulture<Integer> {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/Tiger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/Tiger.java
@@ -17,6 +17,9 @@
 
 package org.jboss.cdi.tck.tests.definition.bean.types;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class Tiger implements Mammal<String> {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/Vulture.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/Vulture.java
@@ -17,6 +17,9 @@
 
 package org.jboss.cdi.tck.tests.definition.bean.types;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class Vulture<T> extends Bird<String, T> {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/illegal/Animal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/illegal/Animal.java
@@ -17,6 +17,9 @@
 
 package org.jboss.cdi.tck.tests.definition.bean.types.illegal;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class Animal<T> {
 
     public final void ping(){

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/illegal/AnimalHolder.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/illegal/AnimalHolder.java
@@ -17,5 +17,8 @@
 
 package org.jboss.cdi.tck.tests.definition.bean.types.illegal;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class AnimalHolder<T extends Animal> {
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/illegal/Bird.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/illegal/Bird.java
@@ -17,6 +17,9 @@
 
 package org.jboss.cdi.tck.tests.definition.bean.types.illegal;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class Bird<T> extends AnimalHolder<Animal<? extends T>> {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/illegal/EagleProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/illegal/EagleProducer.java
@@ -1,7 +1,9 @@
 package org.jboss.cdi.tck.tests.definition.bean.types.illegal;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
 
+@Dependent
 public class EagleProducer<T> {
 
     @Produces

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/name/$Dollar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/name/$Dollar.java
@@ -16,8 +16,10 @@
  */
 package org.jboss.cdi.tck.tests.definition.name;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 @Named
+@Dependent
 public class $Dollar {
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/name/Haddock.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/name/Haddock.java
@@ -16,11 +16,13 @@
  */
 package org.jboss.cdi.tck.tests.definition.name;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Default;
 import jakarta.inject.Named;
 
 @Named
 @Default
+@Dependent
 public class Haddock implements Animal {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/name/JSFBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/name/JSFBean.java
@@ -16,8 +16,10 @@
  */
 package org.jboss.cdi.tck.tests.definition.name;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 @Named
+@Dependent
 public class JSFBean {
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/name/Moose.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/name/Moose.java
@@ -16,11 +16,13 @@
  */
 package org.jboss.cdi.tck.tests.definition.name;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Default;
 import jakarta.inject.Named;
 
 @Named("aMoose")
 @Default
+@Dependent
 public class Moose implements Animal {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/name/_Underscore.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/name/_Underscore.java
@@ -16,9 +16,11 @@
  */
 package org.jboss.cdi.tck.tests.definition.name;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 @Named
+@Dependent
 public class _Underscore {
 
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/name/lowerCase.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/name/lowerCase.java
@@ -16,8 +16,10 @@
  */
 package org.jboss.cdi.tck.tests.definition.name;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 @Named
+@Dependent
 public class lowerCase {
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/Barn.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/Barn.java
@@ -16,8 +16,10 @@
  */
 package org.jboss.cdi.tck.tests.definition.qualifier;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 
+@Dependent
 public class Barn {
     @Inject
     @Tame

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/Cat.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/Cat.java
@@ -16,7 +16,10 @@
  */
 package org.jboss.cdi.tck.tests.definition.qualifier;
 
+import jakarta.enterprise.context.Dependent;
+
 @Synchronous
+@Dependent
 public class Cat {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/ClippedBorderCollie.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/ClippedBorderCollie.java
@@ -16,7 +16,10 @@
  */
 package org.jboss.cdi.tck.tests.definition.qualifier;
 
+import jakarta.enterprise.context.Dependent;
+
 @Hairy(clipped = true)
+@Dependent
 public class ClippedBorderCollie extends BorderCollie {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/Cod.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/Cod.java
@@ -16,11 +16,13 @@
  */
 package org.jboss.cdi.tck.tests.definition.qualifier;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 @Whitefish
 @Chunky(realChunky = true)
 @Named("whitefish")
+@Dependent
 public class Cod implements ScottishFish {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/EnglishBorderCollie.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/EnglishBorderCollie.java
@@ -16,6 +16,9 @@
  */
 package org.jboss.cdi.tck.tests.definition.qualifier;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class EnglishBorderCollie extends BorderCollie {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/Horse.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/Horse.java
@@ -16,7 +16,10 @@
  */
 package org.jboss.cdi.tck.tests.definition.qualifier;
 
+import jakarta.enterprise.context.Dependent;
+
 @Species
+@Dependent
 public class Horse {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/LongHairedDog.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/LongHairedDog.java
@@ -16,7 +16,10 @@
  */
 package org.jboss.cdi.tck.tests.definition.qualifier;
 
+import jakarta.enterprise.context.Dependent;
+
 @Hairy(clipped = false)
+@Dependent
 public class LongHairedDog {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/MiniatureShetlandPony.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/MiniatureShetlandPony.java
@@ -16,6 +16,9 @@
  */
 package org.jboss.cdi.tck.tests.definition.qualifier;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class MiniatureShetlandPony extends ShetlandPony {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/ShetlandPony.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/ShetlandPony.java
@@ -16,6 +16,9 @@
  */
 package org.jboss.cdi.tck.tests.definition.qualifier;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class ShetlandPony extends Horse {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/SpiderProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/SpiderProducer.java
@@ -16,8 +16,10 @@
  */
 package org.jboss.cdi.tck.tests.definition.qualifier;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
 
+@Dependent
 public class SpiderProducer {
 
     @Produces

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/builtin/AnyBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/builtin/AnyBean.java
@@ -16,8 +16,10 @@
  */
 package org.jboss.cdi.tck.tests.definition.qualifier.builtin;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Any;
 
 @Any
+@Dependent
 public class AnyBean {
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/builtin/BeanProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/builtin/BeanProducer.java
@@ -16,10 +16,12 @@
  */
 package org.jboss.cdi.tck.tests.definition.qualifier.builtin;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Named;
 
+@Dependent
 public class BeanProducer {
     
     @Produces

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/builtin/NamedAnyBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/builtin/NamedAnyBean.java
@@ -16,10 +16,12 @@
  */
 package org.jboss.cdi.tck.tests.definition.qualifier.builtin;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Any;
 import jakarta.inject.Named;
 
 @Named
 @Any
+@Dependent
 public class NamedAnyBean {
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/builtin/NamedBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/builtin/NamedBean.java
@@ -16,8 +16,10 @@
  */
 package org.jboss.cdi.tck.tests.definition.qualifier.builtin;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 @Named
+@Dependent
 public class NamedBean {
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/builtin/Order.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/builtin/Order.java
@@ -16,8 +16,10 @@
  */
 package org.jboss.cdi.tck.tests.definition.qualifier.builtin;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 
+@Dependent
 public class Order {
     @Inject
     public Order(OrderProcessor processor) {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/builtin/OrderProcessor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/builtin/OrderProcessor.java
@@ -16,6 +16,9 @@
  */
 package org.jboss.cdi.tck.tests.definition.qualifier.builtin;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class OrderProcessor {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/repeatable/Process.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/repeatable/Process.java
@@ -16,5 +16,8 @@
  */
 package org.jboss.cdi.tck.tests.definition.qualifier.repeatable;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class Process {
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/repeatable/ProcessProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/repeatable/ProcessProducer.java
@@ -16,10 +16,12 @@
  */
 package org.jboss.cdi.tck.tests.definition.qualifier.repeatable;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Event;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Inject;
 
+@Dependent
 public class ProcessProducer {
 
     @Inject

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/BorderCollie.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/BorderCollie.java
@@ -16,6 +16,7 @@
  */
 package org.jboss.cdi.tck.tests.definition.scope;
 
+@DummyStereotype
 public class BorderCollie extends Dog {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/DummyStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/DummyStereotype.java
@@ -1,0 +1,16 @@
+package org.jboss.cdi.tck.tests.definition.scope;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import jakarta.enterprise.inject.Stereotype;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+// technically useless stereotype that only serves as bean defining annotation
+@Stereotype
+@Target({ TYPE })
+@Retention(RUNTIME)
+public @interface DummyStereotype {
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/EnglishBorderCollie.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/EnglishBorderCollie.java
@@ -16,6 +16,7 @@
  */
 package org.jboss.cdi.tck.tests.definition.scope;
 
+@DummyStereotype
 public class EnglishBorderCollie extends BorderCollie {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/GoldenLabrador.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/GoldenLabrador.java
@@ -16,6 +16,7 @@
  */
 package org.jboss.cdi.tck.tests.definition.scope;
 
+@DummyStereotype
 public class GoldenLabrador extends Labrador {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/GoldenRetriever.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/GoldenRetriever.java
@@ -16,6 +16,7 @@
  */
 package org.jboss.cdi.tck.tests.definition.scope;
 
+@DummyStereotype
 public class GoldenRetriever extends Retriever {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/MiniatureClydesdale.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/MiniatureClydesdale.java
@@ -16,6 +16,7 @@
  */
 package org.jboss.cdi.tck.tests.definition.scope;
 
+@DummyStereotype
 public class MiniatureClydesdale extends Clydesdale {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/Order.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/Order.java
@@ -16,6 +16,7 @@
  */
 package org.jboss.cdi.tck.tests.definition.scope;
 
+@DummyStereotype
 public class Order {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/ShetlandPony.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/ShetlandPony.java
@@ -16,6 +16,7 @@
  */
 package org.jboss.cdi.tck.tests.definition.scope;
 
+@DummyStereotype
 public class ShetlandPony extends Horse {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/broken/tooManyScopes/producer/field/ProducerFieldWithTooManyScopeTypes_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/broken/tooManyScopes/producer/field/ProducerFieldWithTooManyScopeTypes_Broken.java
@@ -17,9 +17,11 @@
 package org.jboss.cdi.tck.tests.definition.scope.broken.tooManyScopes.producer.field;
 
 import jakarta.enterprise.context.ConversationScoped;
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.context.SessionScoped;
 import jakarta.enterprise.inject.Produces;
 
+@Dependent
 public class ProducerFieldWithTooManyScopeTypes_Broken {
     @Produces
     @SessionScoped

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/broken/tooManyScopes/producer/method/ProducerMethodWithTooManyScopeTypes_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/broken/tooManyScopes/producer/method/ProducerMethodWithTooManyScopeTypes_Broken.java
@@ -20,6 +20,7 @@ import jakarta.enterprise.context.ConversationScoped;
 import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
 
+@Dependent
 public class ProducerMethodWithTooManyScopeTypes_Broken {
     @Produces
     @ConversationScoped

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/AlternativeAvailabilityTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/AlternativeAvailabilityTest.java
@@ -14,8 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.cdi.tck.tests.alternative;
+package org.jboss.cdi.tck.tests.full.alternative;
 
+import static org.jboss.cdi.tck.TestGroups.CDI_FULL;
 import static org.jboss.cdi.tck.cdi.Sections.ALTERNATIVE_STEREOTYPE;
 import static org.jboss.cdi.tck.cdi.Sections.BEAN;
 import static org.jboss.cdi.tck.cdi.Sections.BEAN_DISCOVERY_STEPS;
@@ -29,25 +30,23 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
-import java.lang.reflect.Type;
-import java.util.HashSet;
-import java.util.Set;
-
 import jakarta.enterprise.inject.spi.Bean;
 import jakarta.enterprise.util.AnnotationLiteral;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.api.Descriptors;
-import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
 import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
 
+import java.lang.reflect.Type;
+import java.util.HashSet;
+import java.util.Set;
+
 @SpecVersion(spec = "cdi", version = "2.0")
+@Test(groups = CDI_FULL)
 public class AlternativeAvailabilityTest extends AbstractTest {
 
     @Deployment

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/Animal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/Animal.java
@@ -14,32 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.cdi.tck.tests.alternative;
+package org.jboss.cdi.tck.tests.full.alternative;
 
-import jakarta.enterprise.inject.Alternative;
-import jakarta.enterprise.inject.Produces;
+public interface Animal {
 
-public class CatProducer {
-
-    @Produces
-    @Wild
-    public static final Cat wildCat = new Cat();
-
-    @Produces
-    @Tame
-    @Alternative
-    public static final Cat cat = new Cat();
-
-    @Produces
-    @Wild
-    public Cat produceWildCat() {
-        return cat;
-    }
-
-    @Produces
-    @Tame
-    @Alternative
-    public Cat produce() {
-        return cat;
-    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/Bird.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/Bird.java
@@ -14,14 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.cdi.tck.tests.alternative;
+package org.jboss.cdi.tck.tests.full.alternative;
 
 import jakarta.enterprise.inject.Default;
 import jakarta.inject.Named;
 
 @EnabledAlternativeStereotype
+@NotEnabledAlternativeStereotype
 @Named
 @Default
-public class Cat implements Animal {
+public class Bird implements Animal {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/BirdProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/BirdProducer.java
@@ -14,22 +14,36 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.cdi.tck.tests.alternative;
+package org.jboss.cdi.tck.tests.full.alternative;
 
-import static java.lang.annotation.ElementType.FIELD;
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.ElementType.PARAMETER;
-import static java.lang.annotation.ElementType.TYPE;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Produces;
 
-import java.lang.annotation.Retention;
-import java.lang.annotation.Target;
+@Dependent
+public class BirdProducer {
 
-import jakarta.inject.Qualifier;
+    @EnabledAlternativeStereotype
+    @Produces
+    @Tame
+    public final Bird tameBird = new Bird();
 
-@Target({ TYPE, METHOD, PARAMETER, FIELD })
-@Retention(RUNTIME)
-@Qualifier
-public @interface Wild {
+    @NotEnabledAlternativeStereotype
+    @Produces
+    @Wild
+    public final Bird wildBird = new Bird();
+
+    @EnabledAlternativeStereotype
+    @Produces
+    @Tame
+    public Bird produceTame() {
+        return new Bird();
+    }
+
+    @NotEnabledAlternativeStereotype
+    @Produces
+    @Wild
+    public Bird produceWild() {
+        return new Bird();
+    }
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/Cat.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/Cat.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source
- * Copyright 2016, Red Hat, Inc., and individual contributors
+ * Copyright 2010, Red Hat, Inc., and individual contributors
  * by the @authors tag. See the copyright.txt in the distribution for a
  * full listing of individual contributors.
  *
@@ -9,12 +9,19 @@
  * You may obtain a copy of the License at
  * http://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
+ * distributed under the License is distributed on an "AS IS" BASIS,  
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.cdi.tck.tests.alternative;
+package org.jboss.cdi.tck.tests.full.alternative;
 
-public class Snake {
+import jakarta.enterprise.inject.Default;
+import jakarta.inject.Named;
+
+@EnabledAlternativeStereotype
+@Named
+@Default
+public class Cat implements Animal {
+
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/CatProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/CatProducer.java
@@ -14,34 +14,34 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.cdi.tck.tests.alternative;
+package org.jboss.cdi.tck.tests.full.alternative;
 
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Alternative;
 import jakarta.enterprise.inject.Produces;
 
-public class BirdProducer {
+@Dependent
+public class CatProducer {
 
-    @EnabledAlternativeStereotype
-    @Produces
-    @Tame
-    public final Bird tameBird = new Bird();
-
-    @NotEnabledAlternativeStereotype
     @Produces
     @Wild
-    public final Bird wildBird = new Bird();
+    public static final Cat wildCat = new Cat();
 
-    @EnabledAlternativeStereotype
     @Produces
     @Tame
-    public Bird produceTame() {
-        return new Bird();
-    }
+    @Alternative
+    public static final Cat cat = new Cat();
 
-    @NotEnabledAlternativeStereotype
     @Produces
     @Wild
-    public Bird produceWild() {
-        return new Bird();
+    public Cat produceWildCat() {
+        return cat;
     }
 
+    @Produces
+    @Tame
+    @Alternative
+    public Cat produce() {
+        return cat;
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/Chicken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/Chicken.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.cdi.tck.tests.alternative;
+package org.jboss.cdi.tck.tests.full.alternative;
 
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.enterprise.inject.Alternative;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/Dog.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/Dog.java
@@ -14,25 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.cdi.tck.tests.alternative;
+package org.jboss.cdi.tck.tests.full.alternative;
 
-import static java.lang.annotation.ElementType.FIELD;
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.ElementType.TYPE;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import jakarta.inject.Named;
 
-import java.lang.annotation.Retention;
-import java.lang.annotation.Target;
-
-import jakarta.enterprise.context.RequestScoped;
-import jakarta.enterprise.inject.Alternative;
-import jakarta.enterprise.inject.Stereotype;
-
-@RequestScoped
-@Stereotype
-@Alternative
-@Target({ TYPE, METHOD, FIELD })
-@Retention(RUNTIME)
-public @interface EnabledAlternativeStereotype {
+@NotEnabledAlternativeStereotype
+@Named
+public class Dog implements Animal {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/EnabledAlternativeStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/EnabledAlternativeStereotype.java
@@ -14,22 +14,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.cdi.tck.tests.alternative;
+package org.jboss.cdi.tck.tests.full.alternative;
 
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.Stereotype;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import jakarta.inject.Qualifier;
-
-@Target({ TYPE, METHOD, PARAMETER, FIELD })
+@RequestScoped
+@Stereotype
+@Alternative
+@Target({ TYPE, METHOD, FIELD })
 @Retention(RUNTIME)
-@Qualifier
-public @interface Tame {
+public @interface EnabledAlternativeStereotype {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/EnabledSheepProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/EnabledSheepProducer.java
@@ -14,12 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.cdi.tck.tests.alternative;
+package org.jboss.cdi.tck.tests.full.alternative;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Alternative;
 import jakarta.enterprise.inject.Produces;
 
 @Alternative
+@Dependent
 public class EnabledSheepProducer {
 
     @Produces

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/Horse.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/Horse.java
@@ -14,12 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.cdi.tck.tests.alternative;
+package org.jboss.cdi.tck.tests.full.alternative;
 
-import jakarta.inject.Named;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.inject.Alternative;
 
-@NotEnabledAlternativeStereotype
-@Named
-public class Dog implements Animal {
+@Alternative
+@RequestScoped
+public class Horse implements Animal {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/NotEnabledAlternativeStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/NotEnabledAlternativeStereotype.java
@@ -14,8 +14,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.cdi.tck.tests.alternative;
+package org.jboss.cdi.tck.tests.full.alternative;
 
-public interface Animal {
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.Stereotype;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@RequestScoped
+@Stereotype
+@Alternative
+@Target({ TYPE, METHOD, FIELD })
+@Retention(RUNTIME)
+public @interface NotEnabledAlternativeStereotype {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/NotEnabledSheepProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/NotEnabledSheepProducer.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source
- * Copyright 2016, Red Hat, Inc., and individual contributors
+ * Copyright 2010, Red Hat, Inc., and individual contributors
  * by the @authors tag. See the copyright.txt in the distribution for a
  * full listing of individual contributors.
  *
@@ -9,28 +9,27 @@
  * You may obtain a copy of the License at
  * http://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
+ * distributed under the License is distributed on an "AS IS" BASIS,  
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.cdi.tck.tests.alternative;
+package org.jboss.cdi.tck.tests.full.alternative;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Alternative;
 import jakarta.enterprise.inject.Produces;
 
-public class SnakeProducer {
+@Alternative
+@Dependent
+public class NotEnabledSheepProducer {
+    @Produces
+    @Tame
+    public static final Sheep sheep = new Sheep();
 
     @Produces
-    @Wild
-    Snake snake = new Snake();
-
-
-    @Produces
-    @Alternative
-    @Wild
-    public Snake produceWildSnake(){
-        return snake;
+    @Tame
+    public Sheep produce() {
+        return sheep;
     }
-
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/Sheep.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/Sheep.java
@@ -14,20 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.cdi.tck.tests.alternative;
+package org.jboss.cdi.tck.tests.full.alternative;
 
-import jakarta.enterprise.inject.Alternative;
-import jakarta.enterprise.inject.Produces;
+public class Sheep {
 
-@Alternative
-public class NotEnabledSheepProducer {
-    @Produces
-    @Tame
-    public static final Sheep sheep = new Sheep();
-
-    @Produces
-    @Tame
-    public Sheep produce() {
-        return sheep;
-    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/Snake.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/Snake.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source
- * Copyright 2010, Red Hat, Inc., and individual contributors
+ * Copyright 2016, Red Hat, Inc., and individual contributors
  * by the @authors tag. See the copyright.txt in the distribution for a
  * full listing of individual contributors.
  *
@@ -9,13 +9,12 @@
  * You may obtain a copy of the License at
  * http://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,  
+ * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.cdi.tck.tests.alternative;
+package org.jboss.cdi.tck.tests.full.alternative;
 
-public class Sheep {
-
+public class Snake {
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/SnakeProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/SnakeProducer.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source
- * Copyright 2010, Red Hat, Inc., and individual contributors
+ * Copyright 2016, Red Hat, Inc., and individual contributors
  * by the @authors tag. See the copyright.txt in the distribution for a
  * full listing of individual contributors.
  *
@@ -9,18 +9,30 @@
  * You may obtain a copy of the License at
  * http://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,  
+ * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.cdi.tck.tests.alternative;
+package org.jboss.cdi.tck.tests.full.alternative;
 
-import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.Produces;
 
-@Alternative
-@RequestScoped
-public class Horse implements Animal {
+@Dependent
+public class SnakeProducer {
+
+    @Produces
+    @Wild
+    Snake snake = new Snake();
+
+
+    @Produces
+    @Alternative
+    @Wild
+    public Snake produceWildSnake(){
+        return snake;
+    }
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/Tame.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/Tame.java
@@ -14,25 +14,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.cdi.tck.tests.alternative;
+package org.jboss.cdi.tck.tests.full.alternative;
 
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import jakarta.inject.Qualifier;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import jakarta.enterprise.context.RequestScoped;
-import jakarta.enterprise.inject.Alternative;
-import jakarta.enterprise.inject.Stereotype;
-
-@RequestScoped
-@Stereotype
-@Alternative
-@Target({ TYPE, METHOD, FIELD })
+@Target({ TYPE, METHOD, PARAMETER, FIELD })
 @Retention(RUNTIME)
-public @interface NotEnabledAlternativeStereotype {
+@Qualifier
+public @interface Tame {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/Wild.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/Wild.java
@@ -14,15 +14,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.cdi.tck.tests.alternative;
+package org.jboss.cdi.tck.tests.full.alternative;
 
-import jakarta.enterprise.inject.Default;
-import jakarta.inject.Named;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
-@EnabledAlternativeStereotype
-@NotEnabledAlternativeStereotype
-@Named
-@Default
-public class Bird implements Animal {
+import jakarta.inject.Qualifier;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Target({ TYPE, METHOD, PARAMETER, FIELD })
+@Retention(RUNTIME)
+@Qualifier
+public @interface Wild {
 
 }


### PR DESCRIPTION
Part one for #289 since I was to keep files per PR at around hundred.

One test was moved to Full group (testing alternatives selected via beans.xml), others are mostly missing bean defining annotations.