### PR TITLE
Address missing bean defining annotations, part 2.

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/BorderCollie.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/BorderCollie.java
@@ -16,6 +16,7 @@
  */
 package org.jboss.cdi.tck.tests.definition.stereotype;
 
+@DummyStereotype
 public class BorderCollie extends LongHairedDog {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/DummyStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/DummyStereotype.java
@@ -1,0 +1,18 @@
+package org.jboss.cdi.tck.tests.definition.stereotype;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import jakarta.enterprise.inject.Stereotype;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+// servers purely as bean defining annotation
+@Stereotype
+@Target({ TYPE, METHOD, FIELD })
+@Retention(RUNTIME)
+public @interface DummyStereotype {
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/EnglishBorderCollie.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/EnglishBorderCollie.java
@@ -16,6 +16,7 @@
  */
 package org.jboss.cdi.tck.tests.definition.stereotype;
 
+@DummyStereotype
 public class EnglishBorderCollie extends BorderCollie {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/MexicanChihuahua.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/MexicanChihuahua.java
@@ -16,6 +16,7 @@
  */
 package org.jboss.cdi.tck.tests.definition.stereotype;
 
+@DummyStereotype
 public class MexicanChihuahua extends Chihuahua {
 
     /**

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/MiniatureClydesdale.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/MiniatureClydesdale.java
@@ -16,6 +16,7 @@
  */
 package org.jboss.cdi.tck.tests.definition.stereotype;
 
+@DummyStereotype
 public class MiniatureClydesdale extends Clydesdale {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/ShetlandPony.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/ShetlandPony.java
@@ -16,6 +16,7 @@
  */
 package org.jboss.cdi.tck.tests.definition.stereotype;
 
+@DummyStereotype
 public class ShetlandPony extends Horse {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/BullTerrier.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/BullTerrier.java
@@ -16,8 +16,10 @@
  */
 package org.jboss.cdi.tck.tests.event;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Observes;
 
+@Dependent
 public class BullTerrier {
     private static boolean multiBindingEventObserved = false;
     private static boolean singleBindingEventObserved = false;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/FarmShop.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/FarmShop.java
@@ -16,9 +16,11 @@
  */
 package org.jboss.cdi.tck.tests.event;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Specializes;
 
 @Specializes
+@Dependent
 public class FarmShop extends Shop {
 
     @Override

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/Farmer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/Farmer.java
@@ -16,8 +16,10 @@
  */
 package org.jboss.cdi.tck.tests.event;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Observes;
 
+@Dependent
 public class Farmer {
 
     public void observeEggLaying(@Observes Egg egg) {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/LazyFarmer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/LazyFarmer.java
@@ -16,5 +16,8 @@
  */
 package org.jboss.cdi.tck.tests.event;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class LazyFarmer extends Farmer {
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/OrangeCheekedWaxbill.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/OrangeCheekedWaxbill.java
@@ -16,7 +16,9 @@
  */
 package org.jboss.cdi.tck.tests.event;
 
+import jakarta.enterprise.context.Dependent;
 
+@Dependent
 public class OrangeCheekedWaxbill {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/Shop.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/Shop.java
@@ -19,8 +19,10 @@ package org.jboss.cdi.tck.tests.event;
 import java.util.HashSet;
 import java.util.Set;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Observes;
 
+@Dependent
 public class Shop {
 
     public static Set<String> observers = new HashSet<String>();

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/StockWatcher.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/StockWatcher.java
@@ -16,8 +16,10 @@
  */
 package org.jboss.cdi.tck.tests.event;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Observes;
 
+@Dependent
 public class StockWatcher {
 
     public void observeStockPrice(@Observes StockPrice price) {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/TerrierObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/TerrierObserver.java
@@ -17,6 +17,7 @@
 
 package org.jboss.cdi.tck.tests.event;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.spi.BeanManager;
 
@@ -24,6 +25,7 @@ import jakarta.enterprise.inject.spi.BeanManager;
  * @author Martin Kouba
  * 
  */
+@Dependent
 public class TerrierObserver {
 
     public static boolean eventObserved = false;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/Volume.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/Volume.java
@@ -16,7 +16,10 @@
  */
 package org.jboss.cdi.tck.tests.event;
 
+import jakarta.enterprise.context.Dependent;
+
 @Tame
+@Dependent
 public class Volume {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/bindingTypes/AnimalAssessment.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/bindingTypes/AnimalAssessment.java
@@ -16,10 +16,12 @@
  */
 package org.jboss.cdi.tck.tests.event.bindingTypes;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Event;
 import jakarta.enterprise.inject.Any;
 import jakarta.inject.Inject;
 
+@Dependent
 public class AnimalAssessment {
     @Inject
     @Any

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/bindingTypes/EventEmitter.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/bindingTypes/EventEmitter.java
@@ -16,9 +16,11 @@
  */
 package org.jboss.cdi.tck.tests.event.bindingTypes;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Event;
 import jakarta.inject.Inject;
 
+@Dependent
 public class EventEmitter {
     @Inject
     @Extra

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/dependentIsConditionalObserver/AlarmSystem.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/dependentIsConditionalObserver/AlarmSystem.java
@@ -16,9 +16,11 @@
  */
 package org.jboss.cdi.tck.tests.event.broken.observer.dependentIsConditionalObserver;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.event.Reception;
 
+@Dependent
 public class AlarmSystem {
     public void onBreakInAttempt(@Observes(notifyObserver = Reception.IF_EXISTS) BreakIn breakIn) {
         assert false;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/inject/InitializerBean_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/inject/InitializerBean_Broken.java
@@ -16,9 +16,11 @@
  */
 package org.jboss.cdi.tck.tests.event.broken.observer.inject;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 
+@Dependent
 public class InitializerBean_Broken {
     @Inject
     public void initialize(@Observes String string) {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/isDisposer/FoxTerrier_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/isDisposer/FoxTerrier_Broken.java
@@ -16,10 +16,12 @@
  */
 package org.jboss.cdi.tck.tests.event.broken.observer.isDisposer;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.Disposes;
 import jakarta.enterprise.inject.spi.BeforeBeanDiscovery;
 
+@Dependent
 public class FoxTerrier_Broken {
     /*
      * (non-Javadoc)

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/isProducer/BorderTerrier_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/isProducer/BorderTerrier_Broken.java
@@ -16,10 +16,12 @@
  */
 package org.jboss.cdi.tck.tests.event.broken.observer.isProducer;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.Produces;
 import jakarta.enterprise.inject.spi.AfterBeanDiscovery;
 
+@Dependent
 public class BorderTerrier_Broken {
     public @Produces
     String observesAfterBeanDiscovery(@Observes AfterBeanDiscovery event) {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/tooManyParameters/Poodle_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/tooManyParameters/Poodle_Broken.java
@@ -16,10 +16,12 @@
  */
 package org.jboss.cdi.tck.tests.event.broken.observer.tooManyParameters;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.event.ObservesAsync;
 import jakarta.enterprise.inject.spi.AfterDeploymentValidation;
 
+@Dependent
 public class Poodle_Broken {
 
     public void observes(@Observes AfterDeploymentValidation beforeBeanDiscovery, @ObservesAsync Boxer anotherDog) {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/tooManyParameters/YorkshireTerrier_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/tooManyParameters/YorkshireTerrier_Broken.java
@@ -16,9 +16,11 @@
  */
 package org.jboss.cdi.tck.tests.event.broken.observer.tooManyParameters;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.spi.AfterBeanDiscovery;
 
+@Dependent
 public class YorkshireTerrier_Broken {
     public void observesAfterBeanDiscovery(@Observes AfterBeanDiscovery beforeBeanDiscovery, @Observes Boxer anotherDog) {
     }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/eventTypes/EventTypeFamilyObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/eventTypes/EventTypeFamilyObserver.java
@@ -16,6 +16,7 @@
  */
 package org.jboss.cdi.tck.tests.event.eventTypes;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Observes;
 
 /**
@@ -24,6 +25,7 @@ import jakarta.enterprise.event.Observes;
  * 
  * @author David Allen
  */
+@Dependent
 public class EventTypeFamilyObserver {
     private static int objectEventQuantity = 0;
     private static int generalEventQuantity = 0;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/eventTypes/TuneSelect.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/eventTypes/TuneSelect.java
@@ -16,10 +16,12 @@
  */
 package org.jboss.cdi.tck.tests.event.eventTypes;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Event;
 import jakarta.enterprise.inject.Any;
 import jakarta.inject.Inject;
 
+@Dependent
 public class TuneSelect<T> {
     @Inject
     @Any

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/Bar.java
@@ -16,10 +16,12 @@
  */
 package org.jboss.cdi.tck.tests.event.fires;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.enterprise.util.TypeLiteral;
 import jakarta.inject.Inject;
 
+@Dependent
 public class Bar {
 
     @Inject

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/DogWhisperer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/DogWhisperer.java
@@ -16,10 +16,12 @@
  */
 package org.jboss.cdi.tck.tests.event.fires;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Event;
 import jakarta.enterprise.inject.Any;
 import jakarta.inject.Inject;
 
+@Dependent
 public class DogWhisperer {
     @Inject
     @Any

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/MiniBar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/MiniBar.java
@@ -19,11 +19,13 @@ package org.jboss.cdi.tck.tests.event.fires;
 import java.util.HashSet;
 import java.util.Set;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Event;
 import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Inject;
 
+@Dependent
 public class MiniBar {
 
     private Set<Item> items = new HashSet<Item>();

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/nonbinding/OwlFinch_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/nonbinding/OwlFinch_Broken.java
@@ -16,10 +16,12 @@
  */
 package org.jboss.cdi.tck.tests.event.fires.nonbinding;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Event;
 import jakarta.enterprise.inject.Any;
 import jakarta.inject.Inject;
 
+@Dependent
 public class OwlFinch_Broken {
     @Inject
     @Any

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/sync/ParisPostOffice.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/sync/ParisPostOffice.java
@@ -16,9 +16,11 @@
  */
 package org.jboss.cdi.tck.tests.event.fires.sync;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 
+@Dependent
 public class ParisPostOffice {
 
     @Inject

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/sync/PraguePostOffice.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/sync/PraguePostOffice.java
@@ -16,9 +16,11 @@
  */
 package org.jboss.cdi.tck.tests.event.fires.sync;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 
+@Dependent
 public class PraguePostOffice {
 
     @Inject

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/implicit/Awards.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/implicit/Awards.java
@@ -16,9 +16,11 @@
  */
 package org.jboss.cdi.tck.tests.event.implicit;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Event;
 import jakarta.enterprise.inject.Any;
 
+@Dependent
 public class Awards {
     private @Any
     @Honors

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/implicit/Registration.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/implicit/Registration.java
@@ -16,10 +16,12 @@
  */
 package org.jboss.cdi.tck.tests.event.implicit;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Event;
 import jakarta.enterprise.inject.Any;
 import jakarta.inject.Inject;
 
+@Dependent
 public class Registration {
     @Inject
     @Any

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/metadata/DuckNotifier.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/metadata/DuckNotifier.java
@@ -20,11 +20,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Event;
 import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.inject.Inject;
 
+@Dependent
 public class DuckNotifier {
 
     @Inject

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/metadata/SimpleEventNotifier.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/metadata/SimpleEventNotifier.java
@@ -16,12 +16,14 @@
  */
 package org.jboss.cdi.tck.tests.event.metadata;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Event;
 import jakarta.enterprise.inject.Any;
 import jakarta.inject.Inject;
 
 import org.jboss.cdi.tck.tests.event.metadata.Bravo.BravoLiteral;
 
+@Dependent
 public class SimpleEventNotifier {
 
     @Inject

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/metadata/broken/initializer/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/metadata/broken/initializer/Foo.java
@@ -16,10 +16,12 @@
  */
 package org.jboss.cdi.tck.tests.event.metadata.broken.initializer;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.spi.EventMetadata;
 import jakarta.inject.Inject;
 
+@Dependent
 public class Foo {
 
     @Inject

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/abortProcessing/ObserverExceptionAbortsProcessingTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/abortProcessing/ObserverExceptionAbortsProcessingTest.java
@@ -18,6 +18,7 @@ package org.jboss.cdi.tck.tests.event.observer.abortProcessing;
 
 import static org.jboss.cdi.tck.cdi.Sections.OBSERVER_NOTIFICATION;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Observes;
 
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -39,6 +40,7 @@ public class ObserverExceptionAbortsProcessingTest extends AbstractTest {
     public static class AnEventType {
     }
 
+    @Dependent
     public static class AnObserverWithException {
         public static boolean wasNotified = false;
         public static final RuntimeException theException = new RuntimeException("RE1");
@@ -49,6 +51,7 @@ public class ObserverExceptionAbortsProcessingTest extends AbstractTest {
         }
     }
 
+    @Dependent
     public static class AnotherObserverWithException {
         public static boolean wasNotified = false;
         public static final RuntimeException theException = new RuntimeException("RE2");

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/async/basic/MixedObservers.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/async/basic/MixedObservers.java
@@ -19,6 +19,7 @@ package org.jboss.cdi.tck.tests.event.observer.async.basic;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import jakarta.annotation.Priority;
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.event.ObservesAsync;
 
@@ -26,6 +27,7 @@ import org.jboss.cdi.tck.util.ActionSequence;
 
 public class MixedObservers {
 
+    @Dependent
     public static class MassachusettsInstituteObserver {
 
         public static final AtomicInteger threadId = new AtomicInteger();
@@ -37,6 +39,7 @@ public class MixedObservers {
         }
     }
 
+    @Dependent
     public static class OxfordUniversityObserver {
 
         public static final AtomicInteger threadId = new AtomicInteger();
@@ -48,6 +51,7 @@ public class MixedObservers {
         }
     }
 
+    @Dependent
     public static class YaleUniversityObserver {
 
         public void observes(@ObservesAsync @American Experiment experiment) {
@@ -57,6 +61,7 @@ public class MixedObservers {
 
     }
 
+    @Dependent
     public static class StandfordUniversityObserver {
 
         public static final AtomicInteger threadId = new AtomicInteger();

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/async/executor/MessageObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/async/executor/MessageObserver.java
@@ -18,8 +18,10 @@ package org.jboss.cdi.tck.tests.event.observer.async.executor;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.ObservesAsync;
 
+@Dependent
 public class MessageObserver {
     
     public static final AtomicBoolean observed = new AtomicBoolean(false);

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/async/handlingExceptions/NewYorkRadioStation.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/async/handlingExceptions/NewYorkRadioStation.java
@@ -19,8 +19,10 @@ package org.jboss.cdi.tck.tests.event.observer.async.handlingExceptions;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.ObservesAsync;
 
+@Dependent
 public class NewYorkRadioStation {
     
     public static AtomicBoolean observed = new AtomicBoolean(false);

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/async/handlingExceptions/ParisRadioStation.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/async/handlingExceptions/ParisRadioStation.java
@@ -19,8 +19,10 @@ package org.jboss.cdi.tck.tests.event.observer.async.handlingExceptions;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.ObservesAsync;
 
+@Dependent
 public class ParisRadioStation {
 
     public static AtomicBoolean observed = new AtomicBoolean(false);

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/async/handlingExceptions/PragueRadioStation.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/async/handlingExceptions/PragueRadioStation.java
@@ -18,8 +18,10 @@ package org.jboss.cdi.tck.tests.event.observer.async.handlingExceptions;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.ObservesAsync;
 
+@Dependent
 public class PragueRadioStation {
 
     public static AtomicBoolean observed = new AtomicBoolean(false);

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/broken/validation/ambiguous/Observer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/broken/validation/ambiguous/Observer.java
@@ -16,8 +16,10 @@
  */
 package org.jboss.cdi.tck.tests.event.observer.broken.validation.ambiguous;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Observes;
 
+@Dependent
 public class Observer {
     public void observe(@Observes String event, Animal animal) {
     }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/broken/validation/unsatisfied/Observer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/broken/validation/unsatisfied/Observer.java
@@ -18,8 +18,10 @@ package org.jboss.cdi.tck.tests.event.observer.broken.validation.unsatisfied;
 
 import java.io.File;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Observes;
 
+@Dependent
 public class Observer {
     public void observe(@Observes String event, File file) {
     }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/checkedException/TeaCupPomeranian.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/checkedException/TeaCupPomeranian.java
@@ -16,8 +16,10 @@
  */
 package org.jboss.cdi.tck.tests.event.observer.checkedException;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Observes;
 
+@Dependent
 public class TeaCupPomeranian {
 
     public static class TooSmallException extends Exception {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/inheritance/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/inheritance/Bar.java
@@ -17,10 +17,13 @@
     
 package org.jboss.cdi.tck.tests.event.observer.inheritance;
 
+import jakarta.enterprise.context.Dependent;
+
 /**
  * @author Martin Kouba
  *
  */
+@Dependent
 public class Bar extends Foo {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/inheritance/Baz.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/inheritance/Baz.java
@@ -17,6 +17,7 @@
 
 package org.jboss.cdi.tck.tests.event.observer.inheritance;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.spi.BeanManager;
 
 import org.jboss.cdi.tck.util.ActionSequence;
@@ -25,6 +26,7 @@ import org.jboss.cdi.tck.util.ActionSequence;
  * @author Martin Kouba
  * 
  */
+@Dependent
 public class Baz extends Bar {
 
     @Override

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/inheritance/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/inheritance/Foo.java
@@ -17,10 +17,13 @@
 
 package org.jboss.cdi.tck.tests.event.observer.inheritance;
 
+import jakarta.enterprise.context.Dependent;
+
 /**
  * @author Martin Kouba
  * 
  */
+@Dependent
 public class Foo extends AbstractEggObserver {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/method/IntegerObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/method/IntegerObserver.java
@@ -17,12 +17,14 @@
 
 package org.jboss.cdi.tck.tests.event.observer.method;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Observes;
 
 /**
  * @author Martin Kouba
  * 
  */
+@Dependent
 public class IntegerObserver {
 
     public static boolean wasNotified = false;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/method/StockWatcher.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/method/StockWatcher.java
@@ -16,8 +16,10 @@
  */
 package org.jboss.cdi.tck.tests.event.observer.method;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Observes;
 
+@Dependent
 public class StockWatcher {
 
     private static Class<?> observerClazz;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/method/TransactionalObservers.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/method/TransactionalObservers.java
@@ -21,8 +21,10 @@ import static jakarta.enterprise.event.TransactionPhase.AFTER_FAILURE;
 import static jakarta.enterprise.event.TransactionPhase.AFTER_SUCCESS;
 import static jakarta.enterprise.event.TransactionPhase.BEFORE_COMPLETION;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Observes;
 
+@Dependent
 public class TransactionalObservers {
     public void train(@Observes(during = BEFORE_COMPLETION) DisobedientDog dog) {
     }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/param/modification/Counter.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/param/modification/Counter.java
@@ -16,6 +16,9 @@
  */
 package org.jboss.cdi.tck.tests.event.observer.param.modification;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class Counter {
 
     private int i = 0;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/param/modification/CounterObserver01.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/param/modification/CounterObserver01.java
@@ -17,9 +17,11 @@
 package org.jboss.cdi.tck.tests.event.observer.param.modification;
 
 import jakarta.annotation.Priority;
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.spi.ObserverMethod;
 
+@Dependent
 public class CounterObserver01 {
 
     public void observe(@Observes @Priority(ObserverMethod.DEFAULT_PRIORITY) Counter counter) {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/param/modification/CounterObserver02.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/param/modification/CounterObserver02.java
@@ -17,9 +17,11 @@
 package org.jboss.cdi.tck.tests.event.observer.param.modification;
 
 import jakarta.annotation.Priority;
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.spi.ObserverMethod;
 
+@Dependent
 public class CounterObserver02 {
 
     public static int count;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/AirConditioner.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/AirConditioner.java
@@ -16,8 +16,10 @@
  */
 package org.jboss.cdi.tck.tests.event.observer.resolve;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Observes;
 
+@Dependent
 public class AirConditioner {
     private Temperature target;
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/BullTerrier.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/BullTerrier.java
@@ -16,8 +16,10 @@
  */
 package org.jboss.cdi.tck.tests.event.observer.resolve;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Observes;
 
+@Dependent
 public class BullTerrier {
     private static boolean multiBindingEventObserved = false;
     private static boolean singleBindingEventObserved = false;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/Cloud.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/Cloud.java
@@ -16,8 +16,10 @@
  */
 package org.jboss.cdi.tck.tests.event.observer.resolve;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Observes;
 
+@Dependent
 public class Cloud {
     public void allocateNewDisk(@Observes DiskSpaceEvent event) {
     }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/DisabledObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/DisabledObserver.java
@@ -16,9 +16,11 @@
  */
 package org.jboss.cdi.tck.tests.event.observer.resolve;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Observes;
 
 @NotEnabled
+@Dependent
 class DisabledObserver {
     public void observeSecret(@Observes @Secret String secretString) {
         if ("fail if disabled observer invoked".equals(secretString)) {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/Pomeranian.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/Pomeranian.java
@@ -16,10 +16,12 @@
  */
 package org.jboss.cdi.tck.tests.event.observer.resolve;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Named;
 
 @Named("Teddy")
+@Dependent
 public class Pomeranian {
     public static Thread notificationThread;
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/PriviledgedObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/PriviledgedObserver.java
@@ -16,8 +16,10 @@
  */
 package org.jboss.cdi.tck.tests.event.observer.resolve;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Observes;
 
+@Dependent
 public class PriviledgedObserver {
     public void observeSecret(@Observes @Secret String secretString) {
     }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/SystemMonitor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/SystemMonitor.java
@@ -16,9 +16,11 @@
  */
 package org.jboss.cdi.tck.tests.event.observer.resolve;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.event.ObservesAsync;
 
+@Dependent
 public class SystemMonitor {
     public void lowBattery(@Observes BatteryEvent e) {
     }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/runtimeException/TeaCupPomeranian.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/runtimeException/TeaCupPomeranian.java
@@ -16,8 +16,10 @@
  */
 package org.jboss.cdi.tck.tests.event.observer.runtimeException;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Observes;
 
+@Dependent
 public class TeaCupPomeranian {
 
     public static class OversizedException extends RuntimeException {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/wildcardAndTypeVariable/BostonTerrier.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/wildcardAndTypeVariable/BostonTerrier.java
@@ -18,8 +18,10 @@ package org.jboss.cdi.tck.tests.event.observer.wildcardAndTypeVariable;
 
 import java.util.List;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Observes;
 
+@Dependent
 public class BostonTerrier {
 
     public static boolean observedTypeVariable;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/binding/DuplicateBindingTypesWhenResolvingTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/binding/DuplicateBindingTypesWhenResolvingTest.java
@@ -18,6 +18,7 @@ package org.jboss.cdi.tck.tests.event.resolve.binding;
 
 import static org.jboss.cdi.tck.cdi.Sections.BM_OBSERVER_METHOD_RESOLUTION;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Observes;
 
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -39,6 +40,7 @@ public class DuplicateBindingTypesWhenResolvingTest extends AbstractTest {
     public static class AnEventType {
     }
 
+    @Dependent
     public static class AnObserver {
         public boolean wasNotified = false;
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/binding/ResolvingChecksBindingTypeMembersTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/binding/ResolvingChecksBindingTypeMembersTest.java
@@ -19,6 +19,7 @@ package org.jboss.cdi.tck.tests.event.resolve.binding;
 import static org.jboss.cdi.tck.cdi.Sections.EVENT_QUALIFIER_TYPES_WITH_MEMBERS;
 import static org.jboss.cdi.tck.cdi.Sections.OBSERVER_METHOD_EVENT_PARAMETER;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Observes;
 
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -41,6 +42,7 @@ public class ResolvingChecksBindingTypeMembersTest extends AbstractTest {
     public static class AnEventType {
     }
 
+    @Dependent
     public static class AnObserver {
         public boolean wasNotified = false;
 
@@ -49,6 +51,7 @@ public class ResolvingChecksBindingTypeMembersTest extends AbstractTest {
         }
     }
 
+    @Dependent
     public static class AnotherObserver {
         public boolean wasNotified = false;
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/typeWithParameters/CheckTypeParametersWhenResolvingObserversTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/typeWithParameters/CheckTypeParametersWhenResolvingObserversTest.java
@@ -24,6 +24,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Event;
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.spi.ObserverMethod;
@@ -191,6 +192,7 @@ public class CheckTypeParametersWhenResolvingObserversTest extends AbstractTest 
         private static final long serialVersionUID = 1L;
     }
 
+    @Dependent
     public static class StringListObserver {
         public boolean wasNotified = false;
 
@@ -199,6 +201,7 @@ public class CheckTypeParametersWhenResolvingObserversTest extends AbstractTest 
         }
     }
 
+    @Dependent
     public static class IntegerListObserver {
         public boolean wasNotified = false;
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/typeWithParameters/ChecksEventTypeWhenResolvingTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/typeWithParameters/ChecksEventTypeWhenResolvingTest.java
@@ -18,6 +18,7 @@ package org.jboss.cdi.tck.tests.event.resolve.typeWithParameters;
 
 import static org.jboss.cdi.tck.cdi.Sections.OBSERVER_METHOD_EVENT_PARAMETER;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Observes;
 
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -39,6 +40,7 @@ public class ChecksEventTypeWhenResolvingTest extends AbstractTest {
     public static class AnEventType {
     }
 
+    @Dependent
     public static class AnObserver {
         public boolean wasNotified = false;
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/typeWithParameters/DogObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/typeWithParameters/DogObserver.java
@@ -17,8 +17,10 @@
 
 package org.jboss.cdi.tck.tests.event.resolve.typeWithParameters;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Observes;
 
+@Dependent
 public class DogObserver extends AbstractObserver {
 
     public static final String SEQUENCE = "dog";

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/typeWithParameters/FooObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/typeWithParameters/FooObserver.java
@@ -18,8 +18,10 @@ package org.jboss.cdi.tck.tests.event.resolve.typeWithParameters;
 
 import java.util.List;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Observes;
 
+@Dependent
 public class FooObserver extends AbstractObserver {
 
     public static final String SEQUENCE = "fooString";

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/typeWithParameters/RawTypeObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/typeWithParameters/RawTypeObserver.java
@@ -18,8 +18,10 @@ package org.jboss.cdi.tck.tests.event.resolve.typeWithParameters;
 
 import java.util.Random;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Observes;
 
+@Dependent
 public class RawTypeObserver {
 
     public static boolean OBSERVED = false;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/typeWithParameters/TypeVariableObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/typeWithParameters/TypeVariableObserver.java
@@ -17,8 +17,10 @@
 
 package org.jboss.cdi.tck.tests.event.resolve.typeWithParameters;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Observes;
 
+@Dependent
 public class TypeVariableObserver extends AbstractObserver {
 
     public static final String SEQUENCE_UPPER = "barTypeVariable";

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/typeWithParameters/WildcardObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/typeWithParameters/WildcardObserver.java
@@ -19,8 +19,10 @@ package org.jboss.cdi.tck.tests.event.resolve.typeWithParameters;
 
 import java.util.List;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Observes;
 
+@Dependent
 public class WildcardObserver extends AbstractObserver {
 
     public static final String SEQUENCE = "quxWildcard";

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/select/SecuritySensor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/select/SecuritySensor.java
@@ -16,10 +16,12 @@
  */
 package org.jboss.cdi.tck.tests.event.select;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Event;
 import jakarta.enterprise.inject.Any;
 import jakarta.inject.Inject;
 
+@Dependent
 public class SecuritySensor {
     @Inject
     @Any

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/injection/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/injection/Foo.java
@@ -17,6 +17,7 @@
 
 package org.jboss.cdi.tck.tests.implementation.builtin.metadata.broken.injection;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.spi.Interceptor;
 import jakarta.inject.Inject;
 
@@ -24,6 +25,7 @@ import jakarta.inject.Inject;
  * @author Martin Kouba
  * 
  */
+@Dependent
 public class Foo {
 
     @Inject

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/injection/intercepted/InterceptedConstructorInjector.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/injection/intercepted/InterceptedConstructorInjector.java
@@ -17,10 +17,12 @@
 
 package org.jboss.cdi.tck.tests.implementation.builtin.metadata.broken.injection.intercepted;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Intercepted;
 import jakarta.enterprise.inject.spi.Bean;
 import jakarta.inject.Inject;
 
+@Dependent
 public class InterceptedConstructorInjector {
 
     @Inject

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/injection/intercepted/InterceptedFieldInjector.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/injection/intercepted/InterceptedFieldInjector.java
@@ -17,10 +17,12 @@
 
 package org.jboss.cdi.tck.tests.implementation.builtin.metadata.broken.injection.intercepted;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Intercepted;
 import jakarta.enterprise.inject.spi.Bean;
 import jakarta.inject.Inject;
 
+@Dependent
 public class InterceptedFieldInjector {
 
     @Inject

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/injection/intercepted/InterceptedInitializerInjector.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/injection/intercepted/InterceptedInitializerInjector.java
@@ -17,10 +17,12 @@
 
 package org.jboss.cdi.tck.tests.implementation.builtin.metadata.broken.injection.intercepted;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Intercepted;
 import jakarta.enterprise.inject.spi.Bean;
 import jakarta.inject.Inject;
 
+@Dependent
 public class InterceptedInitializerInjector {
 
     @Inject

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/MilkDisposer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/MilkDisposer.java
@@ -17,6 +17,7 @@
 
 package org.jboss.cdi.tck.tests.implementation.builtin.metadata.broken.typeparam;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Disposes;
 import jakarta.enterprise.inject.Produces;
 import jakarta.enterprise.inject.spi.Bean;
@@ -25,6 +26,7 @@ import jakarta.enterprise.inject.spi.Bean;
  * @author Martin Kouba
  * 
  */
+@Dependent
 public class MilkDisposer {
 
     @Produces

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/MilkProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/MilkProducer.java
@@ -17,6 +17,7 @@
 
 package org.jboss.cdi.tck.tests.implementation.builtin.metadata.broken.typeparam;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
 import jakarta.enterprise.inject.spi.Bean;
 
@@ -24,6 +25,7 @@ import jakarta.enterprise.inject.spi.Bean;
  * @author Martin Kouba
  * 
  */
+@Dependent
 public class MilkProducer {
 
     @Produces

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/DisposalNonBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/DisposalNonBean.java
@@ -16,8 +16,10 @@
  */
 package org.jboss.cdi.tck.tests.implementation.disposal.method.definition;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Disposes;
 
+@Dependent
 public class DisposalNonBean {
     private static boolean tarantulaDestroyed = false;
     private static boolean webSpiderdestroyed = false;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/SpiderProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/SpiderProducer.java
@@ -16,11 +16,13 @@
  */
 package org.jboss.cdi.tck.tests.implementation.disposal.method.definition;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Disposes;
 import jakarta.enterprise.inject.Produces;
 
+@Dependent
 public class SpiderProducer {
 
     private static boolean tameSpiderDestroyed = false;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/Tarantula.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/Tarantula.java
@@ -16,6 +16,9 @@
  */
 package org.jboss.cdi.tck.tests.implementation.disposal.method.definition;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class Tarantula extends Spider implements DeadlySpider {
     public int getDeathsCaused() {
         return 1;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/initializerUnallowed/SpiderProducer_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/initializerUnallowed/SpiderProducer_Broken.java
@@ -16,10 +16,12 @@
  */
 package org.jboss.cdi.tck.tests.implementation.disposal.method.definition.broken.initializerUnallowed;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Disposes;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Inject;
 
+@Dependent
 public class SpiderProducer_Broken {
 
     @Produces

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/multiParams/SpiderProducer_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/multiParams/SpiderProducer_Broken.java
@@ -16,9 +16,11 @@
  */
 package org.jboss.cdi.tck.tests.implementation.disposal.method.definition.broken.multiParams;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Disposes;
 import jakarta.enterprise.inject.Produces;
 
+@Dependent
 public class SpiderProducer_Broken {
     @Produces
     public static Spider getSpider() {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/multiple/BusFactory.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/multiple/BusFactory.java
@@ -16,9 +16,11 @@
  */
 package org.jboss.cdi.tck.tests.implementation.disposal.method.definition.broken.multiple;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Disposes;
 import jakarta.enterprise.inject.Produces;
 
+@Dependent
 public class BusFactory {
 
     @Produces

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/observes/SpiderProducer_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/observes/SpiderProducer_Broken.java
@@ -16,10 +16,12 @@
  */
 package org.jboss.cdi.tck.tests.implementation.disposal.method.definition.broken.observes;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.Disposes;
 import jakarta.enterprise.inject.Produces;
 
+@Dependent
 public class SpiderProducer_Broken {
 
     @Produces

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/producesUnallowed/SpiderProducer_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/producesUnallowed/SpiderProducer_Broken.java
@@ -16,9 +16,11 @@
  */
 package org.jboss.cdi.tck.tests.implementation.disposal.method.definition.broken.producesUnallowed;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Disposes;
 import jakarta.enterprise.inject.Produces;
 
+@Dependent
 public class SpiderProducer_Broken {
     @Produces
     public static Spider getSpider() {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/unresolvedMethod/Cat.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/unresolvedMethod/Cat.java
@@ -16,5 +16,8 @@
  */
 package org.jboss.cdi.tck.tests.implementation.disposal.method.definition.broken.unresolvedMethod;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class Cat {
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/unresolvedMethod/SpiderProducer_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/unresolvedMethod/SpiderProducer_Broken.java
@@ -16,9 +16,11 @@
  */
 package org.jboss.cdi.tck.tests.implementation.disposal.method.definition.broken.unresolvedMethod;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Disposes;
 import jakarta.enterprise.inject.Produces;
 
+@Dependent
 public class SpiderProducer_Broken {
 
     @Produces

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/validation/ambiguous/Animal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/validation/ambiguous/Animal.java
@@ -17,6 +17,9 @@
 
 package org.jboss.cdi.tck.tests.implementation.disposal.method.definition.broken.validation.ambiguous;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class Animal {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/validation/ambiguous/Cow.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/validation/ambiguous/Cow.java
@@ -17,6 +17,9 @@
 
 package org.jboss.cdi.tck.tests.implementation.disposal.method.definition.broken.validation.ambiguous;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class Cow extends Animal {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/validation/ambiguous/Producer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/validation/ambiguous/Producer.java
@@ -16,9 +16,11 @@
  */
 package org.jboss.cdi.tck.tests.implementation.disposal.method.definition.broken.validation.ambiguous;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Disposes;
 import jakarta.enterprise.inject.Produces;
 
+@Dependent
 public class Producer {
 
     @Produces

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/validation/unsatisfied/Producer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/validation/unsatisfied/Producer.java
@@ -18,9 +18,11 @@ package org.jboss.cdi.tck.tests.implementation.disposal.method.definition.broken
 
 import java.util.List;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Disposes;
 import jakarta.enterprise.inject.Produces;
 
+@Dependent
 public class Producer {
 
     @Produces

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/inheritance/AppleTree.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/inheritance/AppleTree.java
@@ -16,10 +16,12 @@
  */
 package org.jboss.cdi.tck.tests.implementation.disposal.method.definition.inheritance;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Disposes;
 import jakarta.enterprise.inject.Produces;
 
+@Dependent
 public class AppleTree {
 
     @Produces

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/inheritance/Chef.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/inheritance/Chef.java
@@ -16,11 +16,13 @@
  */
 package org.jboss.cdi.tck.tests.implementation.disposal.method.definition.inheritance;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
 
 /**
  * Test that {@link Cook#disposeMeal(Meal)} is not inherited.
  */
+@Dependent
 public class Chef extends Cook {
 
     @Produces

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/inheritance/Cook.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/inheritance/Cook.java
@@ -16,10 +16,12 @@
  */
 package org.jboss.cdi.tck.tests.implementation.disposal.method.definition.inheritance;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Disposes;
 import jakarta.enterprise.inject.Produces;
 
+@Dependent
 public class Cook {
 
     @Produces

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/inheritance/GrannySmithAppleTree.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/inheritance/GrannySmithAppleTree.java
@@ -16,6 +16,9 @@
  */
 package org.jboss.cdi.tck.tests.implementation.disposal.method.definition.inheritance;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class GrannySmithAppleTree extends AppleTree {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/inheritance/GreatGrannySmithAppleTree.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/inheritance/GreatGrannySmithAppleTree.java
@@ -16,11 +16,13 @@
  */
 package org.jboss.cdi.tck.tests.implementation.disposal.method.definition.inheritance;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
 
 /**
  * Test that {@link AppleTree#disposeApple(Apple)} is not inherited.
  */
+@Dependent
 public class GreatGrannySmithAppleTree extends GrannySmithAppleTree {
 
     @Produces


### PR DESCRIPTION
Part two of #289 

This part is purely addition of bean defining annotations.