### PR TITLE
Address missing bean defining annotations, part 3.

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/field/lifecycle/DefangedTarantula.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/field/lifecycle/DefangedTarantula.java
@@ -1,0 +1,21 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.cdi.tck.tests.full.implementation.producer.field.lifecycle;
+
+public class DefangedTarantula extends Tarantula {
+
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/field/lifecycle/ProducerFieldLifecycleTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/field/lifecycle/ProducerFieldLifecycleTest.java
@@ -1,0 +1,31 @@
+package org.jboss.cdi.tck.tests.full.implementation.producer.field.lifecycle;
+
+import static org.jboss.cdi.tck.TestGroups.CDI_FULL;
+import static org.jboss.cdi.tck.cdi.Sections.SPECIALIZATION;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.cdi.tck.AbstractTest;
+import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.test.audit.annotations.SpecAssertion;
+import org.jboss.test.audit.annotations.SpecAssertions;
+import org.jboss.test.audit.annotations.SpecVersion;
+import org.testng.annotations.Test;
+
+@SpecVersion(spec = "cdi", version = "2.0")
+@Test(groups = CDI_FULL)
+public class ProducerFieldLifecycleTest extends AbstractTest {
+
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return new WebArchiveBuilder().withTestClassPackage(ProducerFieldLifecycleTest.class).build();
+    }
+
+    @Test
+    @SpecAssertions({ @SpecAssertion(section = SPECIALIZATION, id = "cd") })
+    public void testProducerFieldFromSpecializingBeanUsed() throws Exception {
+        TarantulaConsumer spiderConsumer = getContextualReference(TarantulaConsumer.class);
+        assert spiderConsumer.getConsumedTarantula() != null;
+        assert spiderConsumer.getConsumedTarantula() instanceof DefangedTarantula;
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/field/lifecycle/SpecializedTarantulaProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/field/lifecycle/SpecializedTarantulaProducer.java
@@ -14,11 +14,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.cdi.tck.tests.implementation.producer.method.definition;
 
+package org.jboss.cdi.tck.tests.full.implementation.producer.field.lifecycle;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Produces;
 import jakarta.enterprise.inject.Specializes;
 
+/**
+ * This bean contains a producer field and specializes another bean which has the same producer field.
+ * 
+ * @author David Allen
+ * 
+ */
 @Specializes
-public class AndalusianChicken extends Chicken {
+@Dependent
+public class SpecializedTarantulaProducer extends TarantulaProducer {
+    @Produces
+    @Tame
+    public Tarantula produceTarantula = new DefangedTarantula();
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/field/lifecycle/Tame.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/field/lifecycle/Tame.java
@@ -1,0 +1,37 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.cdi.tck.tests.full.implementation.producer.field.lifecycle;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import jakarta.inject.Qualifier;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Target({ TYPE, METHOD, PARAMETER, FIELD })
+@Retention(RUNTIME)
+@Documented
+@Qualifier
+public @interface Tame {
+
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/field/lifecycle/Tarantula.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/field/lifecycle/Tarantula.java
@@ -14,8 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.cdi.tck.tests.implementation.producer.field.lifecycle;
+package org.jboss.cdi.tck.tests.full.implementation.producer.field.lifecycle;
 
-public class DefangedTarantula extends Tarantula {
+import org.jboss.cdi.tck.tests.implementation.producer.field.lifecycle.DeadlySpider;
+import org.jboss.cdi.tck.tests.implementation.producer.field.lifecycle.Spider;
+
+public class Tarantula extends Spider implements DeadlySpider {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/field/lifecycle/TarantulaConsumer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/field/lifecycle/TarantulaConsumer.java
@@ -1,0 +1,39 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.cdi.tck.tests.full.implementation.producer.field.lifecycle;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Inject;
+
+/**
+ * This bean contains an injection point for a Tarantula that must be provided by the container via a (static) producer field.
+ * 
+ * @author David Allen
+ * 
+ */
+@Dependent
+public class TarantulaConsumer {
+    @Inject
+    @Tame
+    private Tarantula consumedTarantula;
+
+    public Tarantula getConsumedTarantula() {
+        return consumedTarantula;
+    }
+
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/field/lifecycle/TarantulaProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/field/lifecycle/TarantulaProducer.java
@@ -14,18 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.cdi.tck.tests.implementation.producer.method.definition;
+package org.jboss.cdi.tck.tests.full.implementation.producer.field.lifecycle;
 
-public class Egg {
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Produces;
 
-    private final Chicken mother;
-
-    public Egg(Chicken mother) {
-        this.mother = mother;
-    }
-
-    public Chicken getMother() {
-        return mother;
-    }
+@Dependent
+public class TarantulaProducer {
+    @Produces
+    @Tame
+    public Tarantula produceTarantula = new Tarantula();
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/definition/AndalusianChicken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/definition/AndalusianChicken.java
@@ -14,13 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.cdi.tck.tests.implementation.producer.field.lifecycle;
+package org.jboss.cdi.tck.tests.full.implementation.producer.method.definition;
 
-import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Specializes;
 
-public class TarantulaProducer {
-    @Produces
-    @Tame
-    public Tarantula produceTarantula = new Tarantula();
+@Specializes
+@Dependent
+public class AndalusianChicken extends Chicken {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/definition/Chicken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/definition/Chicken.java
@@ -14,22 +14,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.jboss.cdi.tck.tests.full.implementation.producer.method.definition;
 
-package org.jboss.cdi.tck.tests.implementation.producer.field.lifecycle;
-
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
-import jakarta.enterprise.inject.Specializes;
 
-/**
- * This bean contains a producer field and specializes another bean which has the same producer field.
- * 
- * @author David Allen
- * 
- */
-@Specializes
-public class SpecializedTarantulaProducer extends TarantulaProducer {
+@Dependent
+public class Chicken {
+
     @Produces
-    @Tame
-    public Tarantula produceTarantula = new DefangedTarantula();
+    @Yummy
+    public Egg produceEgg() {
+        return new Egg(this);
+    }
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/definition/Egg.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/definition/Egg.java
@@ -1,0 +1,31 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.cdi.tck.tests.full.implementation.producer.method.definition;
+
+public class Egg {
+
+    private final Chicken mother;
+
+    public Egg(Chicken mother) {
+        this.mother = mother;
+    }
+
+    public Chicken getMother() {
+        return mother;
+    }
+
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/definition/ProducerMethodDefinitionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/definition/ProducerMethodDefinitionTest.java
@@ -1,0 +1,37 @@
+package org.jboss.cdi.tck.tests.full.implementation.producer.method.definition;
+
+import static org.jboss.cdi.tck.TestGroups.CDI_FULL;
+import static org.jboss.cdi.tck.cdi.Sections.MEMBER_LEVEL_INHERITANCE;
+import static org.jboss.cdi.tck.cdi.Sections.SPECIALIZATION;
+import static org.testng.Assert.assertEquals;
+
+import jakarta.enterprise.inject.UnsatisfiedResolutionException;
+import jakarta.enterprise.util.AnnotationLiteral;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.cdi.tck.AbstractTest;
+import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.test.audit.annotations.SpecAssertion;
+import org.jboss.test.audit.annotations.SpecAssertions;
+import org.jboss.test.audit.annotations.SpecVersion;
+import org.testng.annotations.Test;
+
+@SpecVersion(spec = "cdi", version = "2.0")
+@Test(groups = CDI_FULL)
+public class ProducerMethodDefinitionTest extends AbstractTest {
+
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return new WebArchiveBuilder().withTestClassPackage(ProducerMethodDefinitionTest.class).build();
+    }
+
+
+    @Test(expectedExceptions = UnsatisfiedResolutionException.class)
+    @SpecAssertions({ @SpecAssertion(section = MEMBER_LEVEL_INHERITANCE, id = "da"), @SpecAssertion(section = SPECIALIZATION, id = "cb") })
+    public void testNonStaticProducerMethodNotInheritedBySpecializingSubclass() {
+        assertEquals(getBeans(Egg.class, new AnnotationLiteral<Yummy>() {
+        }).size(), 0);
+        getContextualReference(Egg.class, new AnnotationLiteral<Yummy>() {
+        });
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/definition/Yummy.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/definition/Yummy.java
@@ -14,8 +14,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.cdi.tck.tests.implementation.producer.field.lifecycle;
+package org.jboss.cdi.tck.tests.full.implementation.producer.method.definition;
 
-public class Tarantula extends Spider implements DeadlySpider {
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.inject.Qualifier;
+
+@Target({ TYPE, METHOD, PARAMETER, FIELD })
+@Retention(RUNTIME)
+@Documented
+@Qualifier
+public @interface Yummy {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/lifecycle/Animal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/lifecycle/Animal.java
@@ -14,24 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.cdi.tck.tests.implementation.producer.method.definition;
+package org.jboss.cdi.tck.tests.full.implementation.producer.method.lifecycle;
 
-import static java.lang.annotation.ElementType.FIELD;
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.ElementType.PARAMETER;
-import static java.lang.annotation.ElementType.TYPE;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
-
-import java.lang.annotation.Documented;
-import java.lang.annotation.Retention;
-import java.lang.annotation.Target;
-
-import jakarta.inject.Qualifier;
-
-@Target({ TYPE, METHOD, PARAMETER, FIELD })
-@Retention(RUNTIME)
-@Documented
-@Qualifier
-public @interface Yummy {
+public interface Animal {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/lifecycle/DeadlyAnimal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/lifecycle/DeadlyAnimal.java
@@ -1,0 +1,21 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.cdi.tck.tests.full.implementation.producer.method.lifecycle;
+
+public interface DeadlyAnimal {
+
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/lifecycle/DeadlySpider.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/lifecycle/DeadlySpider.java
@@ -1,0 +1,21 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.cdi.tck.tests.full.implementation.producer.method.lifecycle;
+
+public interface DeadlySpider extends DeadlyAnimal {
+
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/lifecycle/Null.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/lifecycle/Null.java
@@ -1,0 +1,37 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.cdi.tck.tests.full.implementation.producer.method.lifecycle;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import jakarta.inject.Qualifier;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Target({ TYPE, METHOD, PARAMETER, FIELD })
+@Retention(RUNTIME)
+@Documented
+@Qualifier
+public @interface Null {
+
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/lifecycle/Pet.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/lifecycle/Pet.java
@@ -1,0 +1,37 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.cdi.tck.tests.full.implementation.producer.method.lifecycle;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import jakarta.inject.Qualifier;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Target({ TYPE, METHOD, PARAMETER, FIELD })
+@Retention(RUNTIME)
+@Documented
+@Qualifier
+public @interface Pet {
+
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/lifecycle/PreferredSpiderProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/lifecycle/PreferredSpiderProducer.java
@@ -14,8 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.cdi.tck.tests.implementation.producer.method.lifecycle;
+package org.jboss.cdi.tck.tests.full.implementation.producer.method.lifecycle;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Disposes;
 import jakarta.enterprise.inject.Produces;
 import jakarta.enterprise.inject.Specializes;
@@ -23,6 +24,7 @@ import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.inject.Inject;
 
 @Specializes
+@Dependent
 public class PreferredSpiderProducer extends SpiderProducer {
     @Inject
     private Web web;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/lifecycle/ProducerMethodLifecycleTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/lifecycle/ProducerMethodLifecycleTest.java
@@ -1,0 +1,43 @@
+package org.jboss.cdi.tck.tests.full.implementation.producer.method.lifecycle;
+
+import static org.jboss.cdi.tck.TestGroups.CDI_FULL;
+import static org.jboss.cdi.tck.cdi.Sections.PRODUCER_OR_DISPOSER_METHODS_INVOCATION;
+import static org.jboss.cdi.tck.cdi.Sections.SPECIALIZATION;
+
+import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.util.AnnotationLiteral;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.cdi.tck.AbstractTest;
+import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.test.audit.annotations.SpecAssertion;
+import org.jboss.test.audit.annotations.SpecAssertions;
+import org.jboss.test.audit.annotations.SpecVersion;
+import org.testng.annotations.Test;
+
+@SpecVersion(spec = "cdi", version = "2.0")
+@Test(groups = CDI_FULL)
+public class ProducerMethodLifecycleTest extends AbstractTest {
+
+    private AnnotationLiteral<Pet> PET_LITERAL = new AnnotationLiteral<Pet>() {
+    };
+
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return new WebArchiveBuilder().withTestClassPackage(ProducerMethodLifecycleTest.class)
+                .build();
+    }
+
+    @Test
+    @SpecAssertions({ @SpecAssertion(section = PRODUCER_OR_DISPOSER_METHODS_INVOCATION, id = "c"), @SpecAssertion(section = SPECIALIZATION, id = "cb") })
+    public void testProducerMethodFromSpecializedBeanUsed() {
+        SpiderProducer.reset();
+        PreferredSpiderProducer.reset();
+        Bean<Tarantula> spiderBean = getBeans(Tarantula.class, PET_LITERAL).iterator().next();
+        CreationalContext<Tarantula> spiderBeanCc = getCurrentManager().createCreationalContext(spiderBean);
+        Tarantula tarantula = spiderBean.create(spiderBeanCc);
+        assert PreferredSpiderProducer.getTarantulaCreated() == tarantula;
+        assert !SpiderProducer.isTarantulaCreated();
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/lifecycle/Spider.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/lifecycle/Spider.java
@@ -1,0 +1,21 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.cdi.tck.tests.full.implementation.producer.method.lifecycle;
+
+public class Spider implements Animal {
+
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/lifecycle/SpiderProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/lifecycle/SpiderProducer.java
@@ -14,16 +14,43 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.cdi.tck.tests.implementation.producer.method.definition;
+package org.jboss.cdi.tck.tests.full.implementation.producer.method.lifecycle;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
 
-public class Chicken {
+@Dependent
+public class SpiderProducer {
+    private static Tarantula tarantulaCreated;
 
     @Produces
-    @Yummy
-    public Egg produceEgg() {
-        return new Egg(this);
+    @Pet
+    public Tarantula produceTarantula() {
+        Tarantula tarantula = new Tarantula("Pete");
+        tarantulaCreated = tarantula;
+        return tarantula;
     }
 
+    @Produces
+    @Null
+    public Spider getNullSpider() {
+        return null;
+    }
+
+    public static boolean isTarantulaCreated() {
+        return tarantulaCreated != null;
+    }
+
+    public static void resetTarantulaCreated() {
+        SpiderProducer.tarantulaCreated = null;
+    }
+
+
+    public static Tarantula getTarantulaCreated() {
+        return tarantulaCreated;
+    }
+
+    public static void reset() {
+        resetTarantulaCreated();
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/lifecycle/Tarantula.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/lifecycle/Tarantula.java
@@ -1,0 +1,39 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.cdi.tck.tests.full.implementation.producer.method.lifecycle;
+
+public class Tarantula extends Spider implements DeadlySpider {
+    private final String value;
+    private static int numberCreated = 0;
+
+    public Tarantula(String value) {
+        this.value = value;
+        numberCreated++;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static int getNumberCreated() {
+        return numberCreated;
+    }
+
+    public static void setNumberCreated(int numberCreated) {
+        Tarantula.numberCreated = numberCreated;
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/lifecycle/Web.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/lifecycle/Web.java
@@ -14,24 +14,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.jboss.cdi.tck.tests.full.implementation.producer.method.lifecycle;
 
-package org.jboss.cdi.tck.tests.implementation.producer.field.lifecycle;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.Dependent;
 
-import jakarta.inject.Inject;
+@Dependent
+public class Web {
+    private Boolean destroyed;
 
-/**
- * This bean contains an injection point for a Tarantula that must be provided by the container via a (static) producer field.
- * 
- * @author David Allen
- * 
- */
-public class TarantulaConsumer {
-    @Inject
-    @Tame
-    private Tarantula consumedTarantula;
-
-    public Tarantula getConsumedTarantula() {
-        return consumedTarantula;
+    public boolean isSpun() {
+        return destroyed != null;
     }
 
+    public boolean isDestroyed() {
+        return Boolean.TRUE.equals(destroyed);
+    }
+
+    @PostConstruct
+    public void spin() {
+        destroyed = false;
+    }
+
+    @PreDestroy
+    public void destroy() {
+        destroyed = true;
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/parameters/IdeaFactory.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/parameters/IdeaFactory.java
@@ -17,10 +17,12 @@
 
 package org.jboss.cdi.tck.tests.implementation.disposal.method.definition.parameters;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Disposes;
 import jakarta.enterprise.inject.Produces;
 import jakarta.enterprise.inject.spi.BeanManager;
 
+@Dependent
 public class IdeaFactory {
 
     @Produces

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/Chicken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/Chicken.java
@@ -16,6 +16,9 @@
  */
 package org.jboss.cdi.tck.tests.implementation.initializer;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class Chicken {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/ChickenHutch.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/ChickenHutch.java
@@ -16,8 +16,10 @@
  */
 package org.jboss.cdi.tck.tests.implementation.initializer;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 
+@Dependent
 public class ChickenHutch {
 
     public Fox fox;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/PreferredChicken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/PreferredChicken.java
@@ -16,7 +16,10 @@
  */
 package org.jboss.cdi.tck.tests.implementation.initializer;
 
+import jakarta.enterprise.context.Dependent;
+
 @Preferred
+@Dependent
 public class PreferredChicken implements ChickenInterface {
 
     public String getName() {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/PremiumChickenHutch.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/PremiumChickenHutch.java
@@ -16,8 +16,10 @@
  */
 package org.jboss.cdi.tck.tests.implementation.initializer;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 
+@Dependent
 public class PremiumChickenHutch {
     private ChickenInterface chicken;
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/StandardChicken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/StandardChicken.java
@@ -16,7 +16,10 @@
  */
 package org.jboss.cdi.tck.tests.implementation.initializer;
 
+import jakarta.enterprise.context.Dependent;
+
 @StandardVariety
+@Dependent
 public class StandardChicken implements ChickenInterface {
 
     public String getName() {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/StandardChickenHutch.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/StandardChickenHutch.java
@@ -16,8 +16,10 @@
  */
 package org.jboss.cdi.tck.tests.implementation.initializer;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 
+@Dependent
 public class StandardChickenHutch {
     private ChickenInterface chicken;
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/broken/generic/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/broken/generic/Bar.java
@@ -19,8 +19,10 @@ package org.jboss.cdi.tck.tests.implementation.initializer.broken.generic;
 import java.util.Collections;
 import java.util.List;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
 
+@Dependent
 public class Bar {
     @Produces
     public List<Integer> produceInts() {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/broken/generic/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/broken/generic/Foo.java
@@ -18,8 +18,10 @@ package org.jboss.cdi.tck.tests.implementation.initializer.broken.generic;
 
 import java.util.List;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 
+@Dependent
 public class Foo {
     private List<?> injectedList;
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/broken/methodAnnotatedProduces/Pheasant_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/broken/methodAnnotatedProduces/Pheasant_Broken.java
@@ -16,9 +16,11 @@
  */
 package org.jboss.cdi.tck.tests.implementation.initializer.broken.methodAnnotatedProduces;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Inject;
 
+@Dependent
 public class Pheasant_Broken {
 
     @Inject

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/broken/parameterAnnotatedAsyncObserves/Food.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/broken/parameterAnnotatedAsyncObserves/Food.java
@@ -16,5 +16,8 @@
  */
 package org.jboss.cdi.tck.tests.implementation.initializer.broken.parameterAnnotatedAsyncObserves;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class Food {
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/broken/parameterAnnotatedAsyncObserves/FoodConsumer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/broken/parameterAnnotatedAsyncObserves/FoodConsumer.java
@@ -16,9 +16,11 @@
  */
 package org.jboss.cdi.tck.tests.implementation.initializer.broken.parameterAnnotatedAsyncObserves;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.ObservesAsync;
 import jakarta.inject.Inject;
 
+@Dependent
 public class FoodConsumer {
 
     @Inject

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/broken/parameterAnnotatedDisposes/Capercaillie_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/broken/parameterAnnotatedDisposes/Capercaillie_Broken.java
@@ -16,9 +16,11 @@
  */
 package org.jboss.cdi.tck.tests.implementation.initializer.broken.parameterAnnotatedDisposes;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Disposes;
 import jakarta.inject.Inject;
 
+@Dependent
 public class Capercaillie_Broken {
 
     @Inject

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/broken/parameterAnnotatedDisposes/ChickenHutch.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/broken/parameterAnnotatedDisposes/ChickenHutch.java
@@ -16,6 +16,9 @@
  */
 package org.jboss.cdi.tck.tests.implementation.initializer.broken.parameterAnnotatedDisposes;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class ChickenHutch {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/broken/parameterAnnotatedObserves/Grouse_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/broken/parameterAnnotatedObserves/Grouse_Broken.java
@@ -16,9 +16,11 @@
  */
 package org.jboss.cdi.tck.tests.implementation.initializer.broken.parameterAnnotatedObserves;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 
+@Dependent
 public class Grouse_Broken {
 
     @Inject

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/BlackWidowProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/BlackWidowProducer.java
@@ -16,9 +16,11 @@
  */
 package org.jboss.cdi.tck.tests.implementation.producer.field.definition;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Named;
 
+@Dependent
 public class BlackWidowProducer {
     public static BlackWidow blackWidow = new BlackWidow();
     @Produces

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/Chicken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/Chicken.java
@@ -16,8 +16,10 @@
  */
 package org.jboss.cdi.tck.tests.implementation.producer.field.definition;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
 
+@Dependent
 public class Chicken {
 
     @Produces

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/FunnelWeaverSpiderConsumer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/FunnelWeaverSpiderConsumer.java
@@ -16,8 +16,10 @@
  */
 package org.jboss.cdi.tck.tests.implementation.producer.field.definition;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 
+@Dependent
 public class FunnelWeaverSpiderConsumer {
     @Inject
     @Spidery

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/FunnelWeaverSpiderProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/FunnelWeaverSpiderProducer.java
@@ -16,8 +16,10 @@
  */
 package org.jboss.cdi.tck.tests.implementation.producer.field.definition;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
 
+@Dependent
 public class FunnelWeaverSpiderProducer {
     private static FunnelWeaver<Spider> spider;
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/InfertileChicken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/InfertileChicken.java
@@ -16,6 +16,9 @@
  */
 package org.jboss.cdi.tck.tests.implementation.producer.field.definition;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class InfertileChicken extends Chicken {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/LameInfertileChicken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/LameInfertileChicken.java
@@ -16,6 +16,9 @@
  */
 package org.jboss.cdi.tck.tests.implementation.producer.field.definition;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class LameInfertileChicken extends InfertileChicken {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/OtherSpiderProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/OtherSpiderProducer.java
@@ -16,9 +16,11 @@
  */
 package org.jboss.cdi.tck.tests.implementation.producer.field.definition;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Named;
 
+@Dependent
 public class OtherSpiderProducer {
 
     public static final BlackWidow BLACK_WIDOW = new BlackWidow();

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/SpiderAsAnimalProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/SpiderAsAnimalProducer.java
@@ -16,8 +16,10 @@
  */
 package org.jboss.cdi.tck.tests.implementation.producer.field.definition;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
 
+@Dependent
 public class SpiderAsAnimalProducer {
     @Produces
     @AsAnimal

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/SpiderListProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/SpiderListProducer.java
@@ -19,8 +19,10 @@ package org.jboss.cdi.tck.tests.implementation.producer.field.definition;
 import java.util.ArrayList;
 import java.util.List;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
 
+@Dependent
 public class SpiderListProducer<T extends Spider> {
     @Produces
     List<T> spiders = new ArrayList<T>();

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/StaticTarantulaProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/StaticTarantulaProducer.java
@@ -17,8 +17,10 @@
 
 package org.jboss.cdi.tck.tests.implementation.producer.field.definition;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
 
+@Dependent
 public class StaticTarantulaProducer {
     @Produces
     @SpiderStereotype

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/TameTarantulaProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/TameTarantulaProducer.java
@@ -16,9 +16,11 @@
  */
 package org.jboss.cdi.tck.tests.implementation.producer.field.definition;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.enterprise.inject.Produces;
 
+@Dependent
 public class TameTarantulaProducer {
     @Produces
     @Foo

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/Tarantula.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/Tarantula.java
@@ -16,6 +16,9 @@
  */
 package org.jboss.cdi.tck.tests.implementation.producer.field.definition;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class Tarantula extends Spider implements DeadlySpider {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/TarantulaProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/TarantulaProducer.java
@@ -16,9 +16,11 @@
  */
 package org.jboss.cdi.tck.tests.implementation.producer.field.definition;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Named;
 
+@Dependent
 public class TarantulaProducer {
 
     @Named

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/array/ParameterizedTypeWithWildcardBrokenProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/array/ParameterizedTypeWithWildcardBrokenProducer.java
@@ -19,10 +19,11 @@ package org.jboss.cdi.tck.tests.implementation.producer.field.definition.broken.
 import java.util.ArrayList;
 import java.util.List;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
 import jakarta.enterprise.inject.Vetoed;
 
-
+@Dependent
 public class ParameterizedTypeWithWildcardBrokenProducer<T> {
 
     @Produces

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/array/TypeVariableBrokenProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/array/TypeVariableBrokenProducer.java
@@ -16,8 +16,10 @@
  */
 package org.jboss.cdi.tck.tests.implementation.producer.field.definition.broken.array;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
 
+@Dependent
 public class TypeVariableBrokenProducer<T> {
 
     @SuppressWarnings("unchecked")

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/inject/FooProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/inject/FooProducer.java
@@ -16,9 +16,11 @@
  */
 package org.jboss.cdi.tck.tests.implementation.producer.field.definition.broken.inject;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Inject;
 
+@Dependent
 public class FooProducer {
     @SuppressWarnings("unused")
     @Produces

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/typeVariable/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/typeVariable/Foo.java
@@ -16,8 +16,10 @@
  */
 package org.jboss.cdi.tck.tests.implementation.producer.field.definition.broken.typeVariable;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
 
+@Dependent
 public class Foo<T> {
     @Produces
     T foo = null;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/typeVariable2/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/typeVariable2/Foo.java
@@ -18,9 +18,11 @@ package org.jboss.cdi.tck.tests.implementation.producer.field.definition.broken.
 
 import java.util.List;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.enterprise.inject.Produces;
 
+@Dependent
 public class Foo<T> {
     @Produces
     @RequestScoped

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/wildcard/SpiderProducerWildCardType_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/wildcard/SpiderProducerWildCardType_Broken.java
@@ -16,8 +16,10 @@
  */
 package org.jboss.cdi.tck.tests.implementation.producer.field.definition.broken.wildcard;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
 
+@Dependent
 public class SpiderProducerWildCardType_Broken {
     @Produces
     public FunnelWeaver<?> getAnotherFunnelWeaver = new FunnelWeaver<Object>();

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/BlackWidowConsumer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/BlackWidowConsumer.java
@@ -17,6 +17,7 @@
 
 package org.jboss.cdi.tck.tests.implementation.producer.field.lifecycle;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 
 /**
@@ -25,6 +26,7 @@ import jakarta.inject.Inject;
  * @author David Allen
  * 
  */
+@Dependent
 public class BlackWidowConsumer {
     @Inject
     @Tame

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/BlackWidowProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/BlackWidowProducer.java
@@ -16,9 +16,11 @@
  */
 package org.jboss.cdi.tck.tests.implementation.producer.field.lifecycle;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Disposes;
 import jakarta.enterprise.inject.Produces;
 
+@Dependent
 public class BlackWidowProducer {
 
     public static boolean blackWidowDestroyed = false;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/BrownRecluseProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/BrownRecluseProducer.java
@@ -16,8 +16,10 @@
  */
 package org.jboss.cdi.tck.tests.implementation.producer.field.lifecycle;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
 
+@Dependent
 public class BrownRecluseProducer {
     @Produces
     protected BrownRecluse spider = new BrownRecluse(5);

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/NullSpiderConsumer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/NullSpiderConsumer.java
@@ -17,6 +17,8 @@
 
 package org.jboss.cdi.tck.tests.implementation.producer.field.lifecycle;
 
+import jakarta.enterprise.context.Dependent;
+
 import java.io.Serializable;
 
 /**
@@ -25,6 +27,7 @@ import java.io.Serializable;
  * @author David Allen
  * 
  */
+@Dependent
 public class NullSpiderConsumer implements Serializable {
     private static final long serialVersionUID = 1L;
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/NullSpiderConsumerForBrokenProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/NullSpiderConsumerForBrokenProducer.java
@@ -19,6 +19,7 @@ package org.jboss.cdi.tck.tests.implementation.producer.field.lifecycle;
 
 import java.io.Serializable;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 
 /**
@@ -27,6 +28,7 @@ import jakarta.inject.Inject;
  * @author David Allen
  * 
  */
+@Dependent
 public class NullSpiderConsumerForBrokenProducer implements Serializable {
     private static final long serialVersionUID = 1L;
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/NullSpiderProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/NullSpiderProducer.java
@@ -17,6 +17,7 @@
 
 package org.jboss.cdi.tck.tests.implementation.producer.field.lifecycle;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
 
 /**
@@ -25,6 +26,7 @@ import jakarta.enterprise.inject.Produces;
  * @author David Allen
  * 
  */
+@Dependent
 public class NullSpiderProducer {
     @Produces
     @Null

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/NullSpiderProducer_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/NullSpiderProducer_Broken.java
@@ -17,6 +17,7 @@
 
 package org.jboss.cdi.tck.tests.implementation.producer.field.lifecycle;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.enterprise.inject.Produces;
 
@@ -26,6 +27,7 @@ import jakarta.enterprise.inject.Produces;
  * @author David Allen
  * 
  */
+@Dependent
 public class NullSpiderProducer_Broken {
     @Produces
     @RequestScoped

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/ProducerFieldLifecycleTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/ProducerFieldLifecycleTest.java
@@ -31,6 +31,8 @@ import jakarta.enterprise.util.AnnotationLiteral;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
+import org.jboss.cdi.tck.tests.full.implementation.producer.field.lifecycle.DefangedTarantula;
+import org.jboss.cdi.tck.tests.full.implementation.producer.field.lifecycle.TarantulaConsumer;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
@@ -73,14 +75,6 @@ public class ProducerFieldLifecycleTest extends AbstractTest {
     public void testProducerFieldBeanCreate() throws Exception {
         BlackWidowConsumer spiderConsumer = getContextualReference(BlackWidowConsumer.class);
         assert spiderConsumer.getInjectedSpider().equals(BlackWidowProducer.blackWidow);
-    }
-
-    @Test
-    @SpecAssertions({ @SpecAssertion(section = SPECIALIZATION, id = "cd") })
-    public void testProducerFieldFromSpecializingBeanUsed() throws Exception {
-        TarantulaConsumer spiderConsumer = getContextualReference(TarantulaConsumer.class);
-        assert spiderConsumer.getConsumedTarantula() != null;
-        assert spiderConsumer.getConsumedTarantula() instanceof DefangedTarantula;
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/StaticTarantulaConsumer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/StaticTarantulaConsumer.java
@@ -17,7 +17,9 @@
 
 package org.jboss.cdi.tck.tests.implementation.producer.field.lifecycle;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
+import org.jboss.cdi.tck.tests.full.implementation.producer.field.lifecycle.Tarantula;
 
 /**
  * This bean contains an injection point for a Tarantula that must be provided by the container via a (static) producer field.
@@ -25,6 +27,7 @@ import jakarta.inject.Inject;
  * @author David Allen
  * 
  */
+@Dependent
 public class StaticTarantulaConsumer {
     @Inject
     @Static

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/StaticTarantulaProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/StaticTarantulaProducer.java
@@ -17,8 +17,11 @@
 
 package org.jboss.cdi.tck.tests.implementation.producer.field.lifecycle;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
+import org.jboss.cdi.tck.tests.full.implementation.producer.field.lifecycle.Tarantula;
 
+@Dependent
 public class StaticTarantulaProducer {
     @Produces
     @Static

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/array/ParameterizedTypeWithWildcardBrokenProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/array/ParameterizedTypeWithWildcardBrokenProducer.java
@@ -19,10 +19,11 @@ package org.jboss.cdi.tck.tests.implementation.producer.method.broken.array;
 import java.util.ArrayList;
 import java.util.List;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
 import jakarta.enterprise.inject.Vetoed;
 
-
+@Dependent
 public class ParameterizedTypeWithWildcardBrokenProducer<T> {
 
     @Produces

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/array/TypeVariableBrokenProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/array/TypeVariableBrokenProducer.java
@@ -16,9 +16,10 @@
  */
 package org.jboss.cdi.tck.tests.implementation.producer.method.broken.array;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
 
-
+@Dependent
 public class TypeVariableBrokenProducer<T> {
 
     @Produces

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterAnnotatedDisposes/SpiderProducer_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterAnnotatedDisposes/SpiderProducer_Broken.java
@@ -16,9 +16,11 @@
  */
 package org.jboss.cdi.tck.tests.implementation.producer.method.broken.parameterAnnotatedDisposes;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Disposes;
 import jakarta.enterprise.inject.Produces;
 
+@Dependent
 public class SpiderProducer_Broken {
 
     @Produces

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterAnnotatedObserves/SpiderProducer_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterAnnotatedObserves/SpiderProducer_Broken.java
@@ -16,9 +16,11 @@
  */
 package org.jboss.cdi.tck.tests.implementation.producer.method.broken.parameterAnnotatedObserves;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.Produces;
 
+@Dependent
 public class SpiderProducer_Broken {
 
     @Produces

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterAnnotatedObservesAsync/BrokenProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterAnnotatedObservesAsync/BrokenProducer.java
@@ -1,8 +1,10 @@
 package org.jboss.cdi.tck.tests.implementation.producer.method.broken.parameterAnnotatedObservesAsync;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.ObservesAsync;
 import jakarta.enterprise.inject.Produces;
 
+@Dependent
 public class BrokenProducer {
 
     @Produces

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterizedTypeWithTypeParameter/DoubleListProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterizedTypeWithTypeParameter/DoubleListProducer.java
@@ -3,9 +3,11 @@ package org.jboss.cdi.tck.tests.implementation.producer.method.broken.parameteri
 import java.util.ArrayList;
 import java.util.List;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.enterprise.inject.Produces;
 
+@Dependent
 public class DoubleListProducer<T> {
 
     @Produces

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterizedTypeWithTypeParameter/GeneralListProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterizedTypeWithTypeParameter/GeneralListProducer.java
@@ -19,9 +19,11 @@ package org.jboss.cdi.tck.tests.implementation.producer.method.broken.parameteri
 import java.util.ArrayList;
 import java.util.List;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.enterprise.inject.Produces;
 
+@Dependent
 public class GeneralListProducer<T> {
 
     @Produces

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterizedTypeWithWildcard/SpiderProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterizedTypeWithWildcard/SpiderProducer.java
@@ -16,8 +16,10 @@
  */
 package org.jboss.cdi.tck.tests.implementation.producer.method.broken.parameterizedTypeWithWildcard;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
 
+@Dependent
 public class SpiderProducer {
 
     @Produces

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterizedTypeWithWildcard/SpidermanProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterizedTypeWithWildcard/SpidermanProducer.java
@@ -16,8 +16,10 @@
  */
 package org.jboss.cdi.tck.tests.implementation.producer.method.broken.parameterizedTypeWithWildcard;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
 
+@Dependent
 public class SpidermanProducer {
 
     @Produces

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/typeVariableReturnType/TProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/typeVariableReturnType/TProducer.java
@@ -16,9 +16,11 @@
  */
 package org.jboss.cdi.tck.tests.implementation.producer.method.broken.typeVariableReturnType;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
 import jakarta.enterprise.inject.spi.InjectionPoint;
 
+@Dependent
 public class TProducer {
     @Produces
     public <T> T create(InjectionPoint point) {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/AppleTree.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/AppleTree.java
@@ -16,8 +16,11 @@
  */
 package org.jboss.cdi.tck.tests.implementation.producer.method.definition;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
+import org.jboss.cdi.tck.tests.full.implementation.producer.method.definition.Yummy;
 
+@Dependent
 public class AppleTree {
     @Produces
     @Yummy

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/BeanWithStaticProducerMethod.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/BeanWithStaticProducerMethod.java
@@ -16,9 +16,12 @@
  */
 package org.jboss.cdi.tck.tests.implementation.producer.method.definition;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Disposes;
 import jakarta.enterprise.inject.Produces;
+import org.jboss.cdi.tck.tests.full.implementation.producer.method.definition.Yummy;
 
+@Dependent
 public class BeanWithStaticProducerMethod {
     static boolean stringDestroyed;
     static boolean yummyDestroyed;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/GeneralListProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/GeneralListProducer.java
@@ -19,8 +19,10 @@ package org.jboss.cdi.tck.tests.implementation.producer.method.definition;
 import java.util.ArrayList;
 import java.util.List;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
 
+@Dependent
 public class GeneralListProducer<T> {
 
     @Produces

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/GrannySmithAppleTree.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/GrannySmithAppleTree.java
@@ -16,6 +16,9 @@
  */
 package org.jboss.cdi.tck.tests.implementation.producer.method.definition;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class GrannySmithAppleTree extends AppleTree {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/GreatGrannySmithAppleTree.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/GreatGrannySmithAppleTree.java
@@ -16,6 +16,9 @@
  */
 package org.jboss.cdi.tck.tests.implementation.producer.method.definition;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class GreatGrannySmithAppleTree extends GrannySmithAppleTree {
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/NonBeanWithStaticProducerMethod.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/NonBeanWithStaticProducerMethod.java
@@ -16,9 +16,12 @@
  */
 package org.jboss.cdi.tck.tests.implementation.producer.method.definition;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Disposes;
 import jakarta.enterprise.inject.Produces;
 
+// this is deliberately not a valid bean declaration, see the constructor
+@Dependent
 public class NonBeanWithStaticProducerMethod {
     public NonBeanWithStaticProducerMethod(String someString) {
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/OakTree.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/OakTree.java
@@ -19,7 +19,9 @@ package org.jboss.cdi.tck.tests.implementation.producer.method.definition;
 import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.enterprise.inject.Produces;
+import org.jboss.cdi.tck.tests.full.implementation.producer.method.definition.Yummy;
 
+@Dependent
 public class OakTree {
     @Produces
     @Dependent

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/ProducerMethodDefinitionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/ProducerMethodDefinitionTest.java
@@ -31,7 +31,6 @@ import static org.jboss.cdi.tck.cdi.Sections.METHOD_CONSTRUCTOR_PARAMETER_QUALIF
 import static org.jboss.cdi.tck.cdi.Sections.PRODUCER_METHOD;
 import static org.jboss.cdi.tck.cdi.Sections.PRODUCER_METHOD_TYPES;
 import static org.jboss.cdi.tck.cdi.Sections.PRODUCER_OR_DISPOSER_METHODS_INVOCATION;
-import static org.jboss.cdi.tck.cdi.Sections.SPECIALIZATION;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
@@ -45,7 +44,6 @@ import jakarta.enterprise.context.spi.CreationalContext;
 import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Default;
 import jakarta.enterprise.inject.IllegalProductException;
-import jakarta.enterprise.inject.UnsatisfiedResolutionException;
 import jakarta.enterprise.inject.literal.NamedLiteral;
 import jakarta.enterprise.inject.spi.Bean;
 import jakarta.enterprise.util.AnnotationLiteral;
@@ -54,6 +52,7 @@ import jakarta.enterprise.util.TypeLiteral;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
+import org.jboss.cdi.tck.tests.full.implementation.producer.method.definition.Yummy;
 import org.jboss.cdi.tck.util.Assert;
 import org.jboss.cdi.tck.util.DependentInstance;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -230,15 +229,6 @@ public class ProducerMethodDefinitionTest extends AbstractTest {
         assertEquals(getBeans(WolfSpider.class, TAME_LITERAL).size(), 1);
         Bean<WolfSpider> wolfSpider = getBeans(WolfSpider.class, TAME_LITERAL).iterator().next();
         assertEquals(wolfSpider.getScope(), RequestScoped.class);
-    }
-
-    @Test(expectedExceptions = UnsatisfiedResolutionException.class)
-    @SpecAssertions({ @SpecAssertion(section = MEMBER_LEVEL_INHERITANCE, id = "da"), @SpecAssertion(section = SPECIALIZATION, id = "cb") })
-    public void testNonStaticProducerMethodNotInheritedBySpecializingSubclass() {
-        assertEquals(getBeans(Egg.class, new AnnotationLiteral<Yummy>() {
-        }).size(), 0);
-        getContextualReference(Egg.class, new AnnotationLiteral<Yummy>() {
-        });
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/SpiderProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/SpiderProducer.java
@@ -16,10 +16,12 @@
  */
 package org.jboss.cdi.tck.tests.implementation.producer.method.definition;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Named;
 
+@Dependent
 public class SpiderProducer {
 
     private static Spider[] ALL_SPIDERS = { new Tarantula(), new LadybirdSpider(), new DaddyLongLegs() };

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/Tarantula.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/Tarantula.java
@@ -16,6 +16,9 @@
  */
 package org.jboss.cdi.tck.tests.implementation.producer.method.definition;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class Tarantula extends Spider implements DeadlySpider {
     public int getDeathsCaused() {
         return 1;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/name/BugProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/name/BugProducer.java
@@ -17,6 +17,7 @@
 
 package org.jboss.cdi.tck.tests.implementation.producer.method.definition.name;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Named;
 
@@ -24,6 +25,7 @@ import jakarta.inject.Named;
  * 
  * @author Martin Kouba
  */
+@Dependent
 public class BugProducer {
 
     @Produces

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/BrownRecluse.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/BrownRecluse.java
@@ -16,9 +16,11 @@
  */
 package org.jboss.cdi.tck.tests.implementation.producer.method.lifecycle;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
 import jakarta.enterprise.inject.spi.BeanManager;
 
+@Dependent
 public class BrownRecluse {
     public @Produces
     @FirstBorn

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/Chicken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/Chicken.java
@@ -16,8 +16,10 @@
  */
 package org.jboss.cdi.tck.tests.implementation.producer.method.lifecycle;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
 
+@Dependent
 public class Chicken {
     private static Egg egg = new Egg();
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/Lays.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/Lays.java
@@ -16,9 +16,11 @@
  */
 package org.jboss.cdi.tck.tests.implementation.producer.method.lifecycle;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.enterprise.inject.Produces;
 
+@Dependent
 public class Lays {
     public @Produces
     @Null

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/LorryProducer_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/LorryProducer_Broken.java
@@ -16,8 +16,10 @@
  */
 package org.jboss.cdi.tck.tests.implementation.producer.method.lifecycle;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
 
+@Dependent
 public class LorryProducer_Broken {
 
     public @Produces

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/ProducerMethodLifecycleTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/ProducerMethodLifecycleTest.java
@@ -19,8 +19,6 @@ package org.jboss.cdi.tck.tests.implementation.producer.method.lifecycle;
 import static org.jboss.cdi.tck.cdi.Sections.CONTEXTUAL;
 import static org.jboss.cdi.tck.cdi.Sections.PRODUCER_METHOD;
 import static org.jboss.cdi.tck.cdi.Sections.PRODUCER_METHOD_LIFECYCLE;
-import static org.jboss.cdi.tck.cdi.Sections.PRODUCER_OR_DISPOSER_METHODS_INVOCATION;
-import static org.jboss.cdi.tck.cdi.Sections.SPECIALIZATION;
 
 import java.util.Set;
 
@@ -55,20 +53,20 @@ public class ProducerMethodLifecycleTest extends AbstractTest {
 
     @Deployment
     public static WebArchive createTestArchive() {
-        return new WebArchiveBuilder().withTestClassPackage(ProducerMethodLifecycleTest.class).withBeansXml("beans.xml")
+        return new WebArchiveBuilder().withTestClassPackage(ProducerMethodLifecycleTest.class)
                 .build();
     }
 
     @Test
     @SpecAssertion(section = PRODUCER_METHOD_LIFECYCLE, id = "ea")
     public void testProducerMethodBeanCreate() {
-        PreferredSpiderProducer.reset();
+        SpiderProducer.reset();
         Bean<Tarantula> tarantulaBean = getBeans(Tarantula.class, PET_LITERAL).iterator().next();
         CreationalContext<Tarantula> tarantulaCc = getCurrentManager().createCreationalContext(tarantulaBean);
         Tarantula tarantula = tarantulaBean.create(tarantulaCc);
-        assert PreferredSpiderProducer.getTarantulaCreated() == tarantula;
-        assert PreferredSpiderProducer.getInjectedWeb() != null;
-        assert PreferredSpiderProducer.getInjectedWeb().isDestroyed();
+        assert SpiderProducer.getTarantulaCreated() == tarantula;
+        assert SpiderProducer.getInjectedWeb() != null;
+        assert SpiderProducer.getInjectedWeb().isDestroyed();
     }
 
     @Test
@@ -89,18 +87,6 @@ public class ProducerMethodLifecycleTest extends AbstractTest {
         }
 
         assert false : "The BeanManager should not have been injected into the producer method";
-    }
-
-    @Test
-    @SpecAssertions({ @SpecAssertion(section = PRODUCER_OR_DISPOSER_METHODS_INVOCATION, id = "c"), @SpecAssertion(section = SPECIALIZATION, id = "cb") })
-    public void testProducerMethodFromSpecializedBeanUsed() {
-        SpiderProducer.reset();
-        PreferredSpiderProducer.reset();
-        Bean<Tarantula> spiderBean = getBeans(Tarantula.class, PET_LITERAL).iterator().next();
-        CreationalContext<Tarantula> spiderBeanCc = getCurrentManager().createCreationalContext(spiderBean);
-        Tarantula tarantula = spiderBean.create(spiderBeanCc);
-        assert PreferredSpiderProducer.getTarantulaCreated() == tarantula;
-        assert !SpiderProducer.isTarantulaCreated();
     }
 
     @Test
@@ -125,20 +111,20 @@ public class ProducerMethodLifecycleTest extends AbstractTest {
     @Test
     @SpecAssertions({ @SpecAssertion(section = PRODUCER_METHOD_LIFECYCLE, id = "ma"), @SpecAssertion(section = PRODUCER_METHOD_LIFECYCLE, id = "r") })
     public void testProducerMethodBeanDestroy() {
-        PreferredSpiderProducer.reset();
+        SpiderProducer.reset();
         Set<Bean<?>> beans = getCurrentManager().getBeans(Tarantula.class, PET_LITERAL);
         Bean<?> bean = getCurrentManager().resolve(beans);
-        assert bean.getBeanClass().equals(PreferredSpiderProducer.class);
+        assert bean.getBeanClass().equals(SpiderProducer.class);
         assert bean.getTypes().contains(Tarantula.class);
         Bean<Tarantula> tarantulaBean = (Bean<Tarantula>) bean;
         CreationalContext<Tarantula> tarantulaCc = getCurrentManager().createCreationalContext(tarantulaBean);
         Tarantula tarantula = tarantulaBean.create(tarantulaCc);
-        PreferredSpiderProducer.resetInjections();
+        SpiderProducer.resetInjections();
         tarantulaBean.destroy(tarantula, tarantulaCc);
-        assert PreferredSpiderProducer.getTarantulaDestroyed() == tarantula;
-        assert PreferredSpiderProducer.isDestroyArgumentsSet();
-        assert PreferredSpiderProducer.getInjectedWeb() != null;
-        assert PreferredSpiderProducer.getInjectedWeb().isDestroyed();
+        assert SpiderProducer.getTarantulaDestroyed() == tarantula;
+        assert SpiderProducer.isDestroyArgumentsSet();
+        assert SpiderProducer.getInjectedWeb() != null;
+        assert SpiderProducer.getInjectedWeb().isDestroyed();
     }
 
     @Test(expectedExceptions = FooException.class)

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/ShipProducer_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/ShipProducer_Broken.java
@@ -16,8 +16,10 @@
  */
 package org.jboss.cdi.tck.tests.implementation.producer.method.lifecycle;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
 
+@Dependent
 public class ShipProducer_Broken {
 
     public @Produces

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/SpiderProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/SpiderProducer.java
@@ -16,16 +16,31 @@
  */
 package org.jboss.cdi.tck.tests.implementation.producer.method.lifecycle;
 
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Disposes;
 import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.inject.Inject;
 
+@Dependent
 public class SpiderProducer {
+
+    @Inject
+    private Web web;
+
     private static Tarantula tarantulaCreated;
+    private static Web injectedWeb;
+    private static boolean destroyArgumentsSet;
+    private static Tarantula tarantulaDestroyed;
 
     @Produces
     @Pet
     public Tarantula produceTarantula() {
         Tarantula tarantula = new Tarantula("Pete");
         tarantulaCreated = tarantula;
+        injectedWeb = web;
+        tarantulaCreated = tarantula;
+        resetTarantulaDestroyed();
         return tarantula;
     }
 
@@ -33,6 +48,14 @@ public class SpiderProducer {
     @Null
     public Spider getNullSpider() {
         return null;
+    }
+
+    public void destroyTarantula(@Disposes @Pet Tarantula spider, BeanManager beanManager) {
+        tarantulaDestroyed = spider;
+        injectedWeb = web;
+        if (beanManager != null) {
+            destroyArgumentsSet = true;
+        }
     }
 
     public static boolean isTarantulaCreated() {
@@ -48,7 +71,33 @@ public class SpiderProducer {
         return tarantulaCreated;
     }
 
+    public static Tarantula getTarantulaDestroyed() {
+        return tarantulaDestroyed;
+    }
+
     public static void reset() {
         resetTarantulaCreated();
     }
+
+    public static void resetInjections() {
+        injectedWeb = null;
+    }
+
+    public static Web getInjectedWeb() {
+        return injectedWeb;
+    }
+
+    public static boolean isDestroyArgumentsSet() {
+        return destroyArgumentsSet;
+    }
+
+    public static void resetTarantulaDestroyed() {
+        tarantulaDestroyed = null;
+        destroyArgumentsSet = false;
+    }
+
+    public static boolean isTarantulaDestroyed() {
+        return tarantulaDestroyed != null;
+    }
+
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/SpiderProducer_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/SpiderProducer_Broken.java
@@ -16,9 +16,11 @@
  */
 package org.jboss.cdi.tck.tests.implementation.producer.method.lifecycle;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.enterprise.inject.Produces;
 
+@Dependent
 public class SpiderProducer_Broken {
 
     @Produces

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/Web.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/Web.java
@@ -18,7 +18,9 @@ package org.jboss.cdi.tck.tests.implementation.producer.method.lifecycle;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.Dependent;
 
+@Dependent
 public class Web {
     private Boolean destroyed;
 

--- a/impl/src/main/resources/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/beans.xml
+++ b/impl/src/main/resources/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/beans.xml
@@ -1,3 +1,0 @@
-<beans> 
-
-</beans>


### PR DESCRIPTION
Part three of #289 

This one moves some tests using specialization under `full` package, rest is again bean defining annotations.