### PR TITLE
Update CDI API, introduce test for Instance.Handle.

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/AbstractTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/AbstractTest.java
@@ -47,7 +47,6 @@ import org.jboss.cdi.tck.util.DependentInstance;
  */
 public abstract class AbstractTest extends Arquillian {
 
-    // TODO this will have to be eventually changes as Lite implementations do not have BeanManager, only BeanContainer
     @Inject
     protected BeanManager beanManager;
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/handle/Alpha.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/handle/Alpha.java
@@ -1,0 +1,28 @@
+package org.jboss.cdi.tck.tests.lookup.dynamic.handle;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.Dependent;
+import org.jboss.cdi.tck.util.ActionSequence;
+
+import java.util.UUID;
+
+@Dependent
+public class Alpha {
+
+    private String id;
+
+    @PostConstruct
+    void init() {
+        this.id = UUID.randomUUID().toString();
+    }
+
+    String getId() {
+        return id;
+    }
+
+    @PreDestroy
+    void destroy() {
+        ActionSequence.addAction(id);
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/handle/Bravo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/handle/Bravo.java
@@ -1,0 +1,28 @@
+package org.jboss.cdi.tck.tests.lookup.dynamic.handle;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.ApplicationScoped;
+import org.jboss.cdi.tck.util.ActionSequence;
+
+import java.util.UUID;
+
+@ApplicationScoped
+public class Bravo {
+
+    private String id;
+
+    @PostConstruct
+    void init() {
+        this.id = UUID.randomUUID().toString();
+    }
+
+    String getId() {
+        return id;
+    }
+
+    @PreDestroy
+    void destroy() {
+        ActionSequence.addAction(id);
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/handle/Client.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/handle/Client.java
@@ -1,0 +1,33 @@
+package org.jboss.cdi.tck.tests.lookup.dynamic.handle;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+import java.math.BigDecimal;
+
+@Dependent
+public class Client {
+
+    @Inject
+    Instance<Alpha> alphaInstance;
+
+    @Inject
+    Instance<Object> instance;
+
+    @Inject
+    @Juicy
+    Instance<BigDecimal> bigDecimalInstance;
+
+    Instance<Alpha> getAlphaInstance() {
+        return alphaInstance;
+    }
+
+    Instance<BigDecimal> getBigDecimalInstance() {
+        return bigDecimalInstance;
+    }
+
+    Instance<Object> getInstance() {
+        return instance;
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/handle/FirstProcessor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/handle/FirstProcessor.java
@@ -1,0 +1,19 @@
+package org.jboss.cdi.tck.tests.lookup.dynamic.handle;
+
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.Dependent;
+import org.jboss.cdi.tck.util.ActionSequence;
+
+@Dependent
+public class FirstProcessor implements Processor {
+
+    @Override
+    public void ping() {
+        ActionSequence.addAction("firstPing");
+    }
+
+    @PreDestroy
+    void destroy() {
+        ActionSequence.addAction("firstDestroy");
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/handle/InstanceHandleTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/handle/InstanceHandleTest.java
@@ -1,0 +1,139 @@
+package org.jboss.cdi.tck.tests.lookup.dynamic.handle;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.cdi.tck.AbstractTest;
+import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
+import org.jboss.cdi.tck.util.ActionSequence;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.test.audit.annotations.SpecVersion;
+import org.testng.annotations.Test;
+
+import java.util.Iterator;
+import java.util.List;
+
+@SpecVersion(spec = "cdi", version = "4.0")
+public class InstanceHandleTest extends AbstractTest {
+
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return new WebArchiveBuilder().withTestClassPackage(InstanceHandleTest.class).build();
+    }
+
+    //@SpecAssertion(section = PROGRAMMATIC_LOOKUP, id = "TODO")
+    @Test
+    public void testIsResolvable() {
+        Client client = getContextualReference(Client.class);
+        ActionSequence.reset();
+        assertNotNull(client);
+        assertTrue(client.getAlphaInstance().isResolvable());
+        assertFalse(client.getBigDecimalInstance().isResolvable());
+    }
+
+    //@SpecAssertion(section = PROGRAMMATIC_LOOKUP, id = "TODO")
+    @Test
+    public void testGetHandle() {
+        Client client = getContextualReference(Client.class);
+        BeanManager beanManager = getCurrentManager();
+
+        ActionSequence.reset();
+        assertNotNull(client);
+
+        Bean<?> alphaBean = beanManager.resolve(beanManager.getBeans(Alpha.class));
+        Instance<Alpha> instance = client.getAlphaInstance();
+
+        Instance.Handle<Alpha> alpha1 = instance.getHandle();
+        assertEquals(alphaBean, alpha1.getBean());
+        assertEquals(Dependent.class, alpha1.getBean().getScope());
+
+        String alpha2Id;
+
+        // Test try-with-resource
+        try (Instance.Handle<Alpha> alpha2 = instance.getHandle()) {
+            alpha2Id = alpha2.get().getId();
+            assertFalse(alpha1.get().getId().equals(alpha2Id));
+        }
+
+        List<String> sequence = ActionSequence.getSequenceData();
+        assertEquals(1, sequence.size());
+        assertEquals(alpha2Id, sequence.get(0));
+
+        alpha1.destroy();
+        // Subsequent invocations are no-op
+        alpha1.destroy();
+
+        sequence = ActionSequence.getSequenceData();
+        assertEquals(2, sequence.size());
+
+        // Test normal scoped bean is also destroyed
+        Instance<Bravo> bravoInstance = client.getInstance().select(Bravo.class);
+        String bravoId = bravoInstance.get().getId();
+        try (Instance.Handle<Bravo> bravo = bravoInstance.getHandle()) {
+            assertEquals(bravoId, bravo.get().getId());
+            ActionSequence.reset();
+        }
+        sequence = ActionSequence.getSequenceData();
+        assertEquals(1, sequence.size());
+        assertEquals(bravoId, sequence.get(0));
+    }
+
+    //@SpecAssertion(section = PROGRAMMATIC_LOOKUP, id = "TODO")
+    @Test
+    public void testGetAfterDestroyingContextualInstance() {
+        ActionSequence.reset();
+        Client client = getContextualReference(Client.class);
+        assertNotNull(client);
+
+        Instance.Handle<Alpha> alphaHandle = client.getAlphaInstance().getHandle();
+        // trigger bean creation
+        alphaHandle.get();
+        // trigger bean destruction
+        alphaHandle.destroy();
+        // verify that the destruction happened
+        List<String> sequence = ActionSequence.getSequenceData();
+        assertEquals(1, sequence.size());
+
+        // try to invoke Handle.get() again; this should throw an exception
+        try {
+            alphaHandle.get();
+            fail("Invoking Handle.get() after destroying contextual instance should throw an exception.");
+        } catch (IllegalStateException e) {
+            // expected
+        }
+    }
+
+    //@SpecAssertion(section = PROGRAMMATIC_LOOKUP, id = "TODO")
+    @Test
+    public void testHandles() {
+        Instance<Processor> instance = getCurrentManager().createInstance().select(Processor.class);
+        ActionSequence.reset();
+        assertTrue(instance.isAmbiguous());
+        for (Instance.Handle<Processor> handle : instance.handles()) {
+            handle.get().ping();
+            if (handle.getBean().getScope().equals(Dependent.class)) {
+                handle.destroy();
+            }
+        }
+        assertEquals(3, ActionSequence.getSequenceSize());
+        ActionSequence.assertSequenceDataContainsAll("firstPing", "secondPing", "firstDestroy");
+
+        ActionSequence.reset();
+        assertTrue(instance.isAmbiguous());
+        for (Iterator<Instance.Handle<Processor>> iterator = instance.handles().iterator(); iterator.hasNext(); ) {
+            try (Instance.Handle<Processor> handle = iterator.next()) {
+                handle.get().ping();
+            }
+        }
+        assertEquals(4, ActionSequence.getSequenceSize());
+        ActionSequence.assertSequenceDataContainsAll("firstPing", "secondPing", "firstDestroy", "secondDestroy");
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/handle/Juicy.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/handle/Juicy.java
@@ -1,0 +1,28 @@
+package org.jboss.cdi.tck.tests.lookup.dynamic.handle;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.inject.Qualifier;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Qualifier
+@Target({ TYPE, METHOD, PARAMETER, FIELD })
+@Retention(RUNTIME)
+public @interface Juicy {
+
+    @SuppressWarnings("all")
+    public static class Literal extends AnnotationLiteral<Juicy> implements Juicy {
+
+        private Literal() {
+        }
+
+        public static final Literal INSTANCE = new Literal();
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/handle/Processor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/handle/Processor.java
@@ -1,0 +1,6 @@
+package org.jboss.cdi.tck.tests.lookup.dynamic.handle;
+
+public interface Processor {
+
+    void ping();
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/handle/SecondProcessor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/handle/SecondProcessor.java
@@ -1,0 +1,19 @@
+package org.jboss.cdi.tck.tests.lookup.dynamic.handle;
+
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.ApplicationScoped;
+import org.jboss.cdi.tck.util.ActionSequence;
+
+@ApplicationScoped
+public class SecondProcessor implements Processor {
+
+    @Override
+    public void ping() {
+        ActionSequence.addAction("secondPing");
+    }
+
+    @PreDestroy
+    void destroy() {
+        ActionSequence.addAction("secondDestroy");
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/customCDIProvider/CustomCDIProvider.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/customCDIProvider/CustomCDIProvider.java
@@ -80,6 +80,16 @@ public class CustomCDIProvider implements CDIProvider {
         }
 
         @Override
+        public Handle<Object> getHandle() {
+            return null;
+        }
+
+        @Override
+        public Iterable<Handle<Object>> handles() {
+            return null;
+        }
+
+        @Override
         public Object get() {
             return null;
         }

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
 
     <properties>
         <!-- CDI API -->
-        <cdi.api.version>4.0.0.Alpha3</cdi.api.version>
+        <cdi.api.version>4.0.0.Beta1</cdi.api.version>
         <maven.compiler.release>11</maven.compiler.release>
         <!-- Jakarta EE APIs Core -->
         <annotations.api.version>2.0.0</annotations.api.version>


### PR DESCRIPTION
Fixes #303 

Introduces a test for `Instance.Handle` that asserts bean metadata, resolution and bean destruction (copied from Weld TS).
Also updates CDI API to latest version.
Lastly, I removed a `TODO` note in `AbstractTest` because we can now happily keep using `BeanManager` in these tests.