### PR TITLE
Move UnsatisfiedInjectableReferenceTest and AmbiguousInjectableRefere…

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/broken/reference/ambiguous/AmbiguousInjectableReferenceTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/broken/reference/ambiguous/AmbiguousInjectableReferenceTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.jboss.cdi.tck.tests.lookup.injectionpoint.broken.reference.ambiguous;
+package org.jboss.cdi.tck.tests.full.lookup.injectionpoint.broken.reference.ambiguous;
 
 import static org.jboss.cdi.tck.TestGroups.CDI_FULL;
 import static org.jboss.cdi.tck.cdi.Sections.BM_OBTAIN_INJECTABLE_REFERENCE;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/broken/reference/ambiguous/AmbiguousInjectionPoint.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/broken/reference/ambiguous/AmbiguousInjectionPoint.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.cdi.tck.tests.lookup.injectionpoint.broken.reference.unresolved;
+package org.jboss.cdi.tck.tests.full.lookup.injectionpoint.broken.reference.ambiguous;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Member;
@@ -29,13 +29,12 @@ import jakarta.enterprise.inject.spi.AnnotatedField;
 import jakarta.enterprise.inject.spi.Bean;
 import jakarta.enterprise.inject.spi.InjectionPoint;
 
-public class UnsatisfiedInjectionPoint implements InjectionPoint {
-
+public class AmbiguousInjectionPoint implements InjectionPoint {
     private final Bean<SimpleBean> bean;
     private final Set<Annotation> bindings = new HashSet<Annotation>();
 
-    public UnsatisfiedInjectionPoint(Bean<SimpleBean> beanWithInjectionPoint) {
-        this.bean = beanWithInjectionPoint;
+    public AmbiguousInjectionPoint(Bean<SimpleBean> bean) {
+        this.bean = bean;
         bindings.add(Default.Literal.INSTANCE);
         bindings.add(Any.Literal.INSTANCE);
     }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/broken/reference/ambiguous/AnnotatedInjectionField.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/broken/reference/ambiguous/AnnotatedInjectionField.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.cdi.tck.tests.lookup.injectionpoint.broken.reference.unresolved;
+package org.jboss.cdi.tck.tests.full.lookup.injectionpoint.broken.reference.ambiguous;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
@@ -54,7 +54,7 @@ public class AnnotatedInjectionField implements AnnotatedField<InjectedBean> {
     }
 
     @Override
-    public <T extends Annotation> Set<T> getAnnotations(Class<T> annotationType) {
+    public <T extends Annotation> Set<T> getAnnotations(Class<T> aClass) {
         return null;
     }
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/broken/reference/ambiguous/DerivedInjectedBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/broken/reference/ambiguous/DerivedInjectedBean.java
@@ -14,19 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.cdi.tck.tests.lookup.injectionpoint.broken.reference.ambiguous;
+package org.jboss.cdi.tck.tests.full.lookup.injectionpoint.broken.reference.ambiguous;
 
 import jakarta.enterprise.context.Dependent;
 
 @Dependent
-public class SimpleBean {
-    private InjectedBean injectedBean;
+public class DerivedInjectedBean extends InjectedBean {
 
-    public InjectedBean getInjectedBean() {
-        return injectedBean;
-    }
-
-    public void setInjectedBean(InjectedBean injectedBean) {
-        this.injectedBean = injectedBean;
-    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/broken/reference/ambiguous/InjectedBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/broken/reference/ambiguous/InjectedBean.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.cdi.tck.tests.lookup.injectionpoint.broken.reference.ambiguous;
+package org.jboss.cdi.tck.tests.full.lookup.injectionpoint.broken.reference.ambiguous;
 
 import jakarta.enterprise.context.Dependent;
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/broken/reference/ambiguous/SimpleBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/broken/reference/ambiguous/SimpleBean.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.cdi.tck.tests.lookup.injectionpoint.broken.reference.unresolved;
+package org.jboss.cdi.tck.tests.full.lookup.injectionpoint.broken.reference.ambiguous;
 
 import jakarta.enterprise.context.Dependent;
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/broken/reference/unresolved/AnnotatedInjectionField.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/broken/reference/unresolved/AnnotatedInjectionField.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.cdi.tck.tests.lookup.injectionpoint.broken.reference.ambiguous;
+package org.jboss.cdi.tck.tests.full.lookup.injectionpoint.broken.reference.unresolved;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
@@ -54,7 +54,7 @@ public class AnnotatedInjectionField implements AnnotatedField<InjectedBean> {
     }
 
     @Override
-    public <T extends Annotation> Set<T> getAnnotations(Class<T> aClass) {
+    public <T extends Annotation> Set<T> getAnnotations(Class<T> annotationType) {
         return null;
     }
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/broken/reference/unresolved/InjectedBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/broken/reference/unresolved/InjectedBean.java
@@ -14,11 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.cdi.tck.tests.lookup.injectionpoint.broken.reference.ambiguous;
+package org.jboss.cdi.tck.tests.full.lookup.injectionpoint.broken.reference.unresolved;
 
 import jakarta.enterprise.context.Dependent;
 
 @Dependent
-public class DerivedInjectedBean extends InjectedBean {
+public class InjectedBean {
+    public InjectedBean(String name) {
 
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/broken/reference/unresolved/SimpleBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/broken/reference/unresolved/SimpleBean.java
@@ -14,13 +14,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.cdi.tck.tests.lookup.injectionpoint.broken.reference.unresolved;
+package org.jboss.cdi.tck.tests.full.lookup.injectionpoint.broken.reference.unresolved;
 
 import jakarta.enterprise.context.Dependent;
 
 @Dependent
-public class InjectedBean {
-    public InjectedBean(String name) {
+public class SimpleBean {
+    private InjectedBean injectedBean;
 
+    public InjectedBean getInjectedBean() {
+        return injectedBean;
+    }
+
+    public void setInjectedBean(InjectedBean injectedBean) {
+        this.injectedBean = injectedBean;
     }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/broken/reference/unresolved/UnsatisfiedInjectableReferenceTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/broken/reference/unresolved/UnsatisfiedInjectableReferenceTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.jboss.cdi.tck.tests.lookup.injectionpoint.broken.reference.unresolved;
+package org.jboss.cdi.tck.tests.full.lookup.injectionpoint.broken.reference.unresolved;
 
 import static org.jboss.cdi.tck.TestGroups.CDI_FULL;
 import static org.jboss.cdi.tck.cdi.Sections.BM_OBTAIN_INJECTABLE_REFERENCE;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/broken/reference/unresolved/UnsatisfiedInjectionPoint.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/broken/reference/unresolved/UnsatisfiedInjectionPoint.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.cdi.tck.tests.lookup.injectionpoint.broken.reference.ambiguous;
+package org.jboss.cdi.tck.tests.full.lookup.injectionpoint.broken.reference.unresolved;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Member;
@@ -29,12 +29,13 @@ import jakarta.enterprise.inject.spi.AnnotatedField;
 import jakarta.enterprise.inject.spi.Bean;
 import jakarta.enterprise.inject.spi.InjectionPoint;
 
-public class AmbiguousInjectionPoint implements InjectionPoint {
+public class UnsatisfiedInjectionPoint implements InjectionPoint {
+
     private final Bean<SimpleBean> bean;
     private final Set<Annotation> bindings = new HashSet<Annotation>();
 
-    public AmbiguousInjectionPoint(Bean<SimpleBean> bean) {
-        this.bean = bean;
+    public UnsatisfiedInjectionPoint(Bean<SimpleBean> beanWithInjectionPoint) {
+        this.bean = beanWithInjectionPoint;
         bindings.add(Default.Literal.INSTANCE);
         bindings.add(Any.Literal.INSTANCE);
     }


### PR DESCRIPTION
…nceTest under appropriate package.

Fixes #320 

These tests were already categorized as Full but for some reason were not under the `full` package.