### PR TITLE
Introduce simple test for OM#getDeclaringBean

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/method/ObserverMethodTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/method/ObserverMethodTest.java
@@ -20,12 +20,15 @@ package org.jboss.cdi.tck.tests.event.observer.method;
 import static org.jboss.cdi.tck.cdi.Sections.OBSERVER_METHOD;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 import java.util.Set;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Reception;
 import jakarta.enterprise.event.TransactionPhase;
+import jakarta.enterprise.inject.spi.Bean;
 import jakarta.enterprise.inject.spi.ObserverMethod;
 import jakarta.enterprise.util.AnnotationLiteral;
 
@@ -56,6 +59,19 @@ public class ObserverMethodTest extends AbstractTest {
         assertEquals(observers.size(), 1);
         ObserverMethod<? super StockPrice> observerMethod = observers.iterator().next();
         assertEquals(observerMethod.getBeanClass(), StockWatcher.class);
+    }
+
+    @Test
+    //@SpecAssertion(section = TODO, id = "TODO")
+    public void testGetDeclaringBeanOnObserverMethod() {
+        Set<ObserverMethod<? super StockPrice>> observers = getCurrentManager().resolveObserverMethods(new StockPrice());
+        assertEquals(observers.size(), 1);
+        ObserverMethod<? super StockPrice> observerMethod = observers.iterator().next();
+        Bean<?> declaringBean = observerMethod.getDeclaringBean();
+        assertNotNull(declaringBean);
+        assertEquals(declaringBean.getBeanClass(), StockWatcher.class);
+        assertEquals(declaringBean.getScope(), Dependent.class);
+        assertTrue(declaringBean.isAlternative());
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/method/StockWatcher.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/method/StockWatcher.java
@@ -16,10 +16,14 @@
  */
 package org.jboss.cdi.tck.tests.event.observer.method;
 
+import jakarta.annotation.Priority;
 import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.Alternative;
 
 @Dependent
+@Alternative
+@Priority(1)
 public class StockWatcher {
 
     private static Class<?> observerClazz;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/handle/InstanceHandleTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/handle/InstanceHandleTest.java
@@ -128,7 +128,7 @@ public class InstanceHandleTest extends AbstractTest {
 
         ActionSequence.reset();
         assertTrue(instance.isAmbiguous());
-        for (Iterator<Instance.Handle<Processor>> iterator = instance.handles().iterator(); iterator.hasNext(); ) {
+        for (Iterator<? extends Instance.Handle<Processor>> iterator = instance.handles().iterator(); iterator.hasNext(); ) {
             try (Instance.Handle<Processor> handle = iterator.next()) {
                 handle.get().ping();
             }

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
 
     <properties>
         <!-- CDI API -->
-        <cdi.api.version>4.0.0.Beta2</cdi.api.version>
+        <cdi.api.version>4.0.0.Beta3</cdi.api.version>
         <maven.compiler.release>11</maven.compiler.release>
         <!-- Jakarta EE APIs Core -->
         <annotations.api.version>2.1.0-B1</annotations.api.version>


### PR DESCRIPTION
Fixes #324 

First commit is the test addition, second is a small correction to unrelated needed because of generics change in CDI API.

Creating as a draft because this PR will also need a bump in CDI API version.
