### PR TITLE
Add negative tests for build compatible extensions with invalid metho…

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/AbstractInvalidExtensionParamTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/AbstractInvalidExtensionParamTest.java
@@ -1,0 +1,28 @@
+package org.jboss.cdi.tck.tests.build.compatible.extensions.invalid;
+
+import org.jboss.cdi.tck.AbstractTest;
+import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
+import org.jboss.shrinkwrap.impl.BeansXml;
+import org.testng.annotations.Test;
+
+public abstract class AbstractInvalidExtensionParamTest extends AbstractTest {
+
+    /**
+     * Prepared archive builder minus the extension being tested
+     */
+    static WebArchiveBuilder prepareArchiveBuilder() {
+        return new WebArchiveBuilder()
+                // add some class that will be type-discovered
+                .withClasses(SomeBean.class)
+                .withTestClass(AbstractInvalidExtensionParamTest.class)
+                // annotated discovery mode
+                .withBeansXml(new BeansXml());
+    }
+
+
+    @Test()
+    //@SpecAssertion(section = TODO, id = "TODO")
+    public void test() {
+        // deployment should fail
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementMultipleParams2Test.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementMultipleParams2Test.java
@@ -1,0 +1,17 @@
+package org.jboss.cdi.tck.tests.build.compatible.extensions.invalid;
+
+import jakarta.enterprise.inject.spi.DefinitionException;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.ShouldThrowException;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.test.audit.annotations.SpecVersion;
+
+@SpecVersion(spec = "cdi", version = "4.0")
+public class EnhancementMultipleParams2Test extends AbstractInvalidExtensionParamTest {
+
+    @ShouldThrowException(DefinitionException.class)
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return prepareArchiveBuilder().withBuildCompatibleExtension(EnhancementMultipleParamsExtension2.class).build();
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementMultipleParamsExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementMultipleParamsExtension.java
@@ -1,0 +1,15 @@
+package org.jboss.cdi.tck.tests.build.compatible.extensions.invalid;
+
+import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;
+import jakarta.enterprise.inject.build.compatible.spi.ClassConfig;
+import jakarta.enterprise.inject.build.compatible.spi.Enhancement;
+import jakarta.enterprise.inject.build.compatible.spi.Messages;
+import jakarta.enterprise.lang.model.declarations.ClassInfo;
+
+public class EnhancementMultipleParamsExtension implements BuildCompatibleExtension {
+
+    @Enhancement(types = SomeBean.class)
+    public void enhance(ClassConfig cc, ClassInfo ci, Messages msg) {
+        // no-op deployment should fail
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementMultipleParamsExtension2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementMultipleParamsExtension2.java
@@ -1,0 +1,15 @@
+package org.jboss.cdi.tck.tests.build.compatible.extensions.invalid;
+
+import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;
+import jakarta.enterprise.inject.build.compatible.spi.ClassConfig;
+import jakarta.enterprise.inject.build.compatible.spi.Enhancement;
+import jakarta.enterprise.inject.build.compatible.spi.MethodConfig;
+import jakarta.enterprise.lang.model.declarations.FieldInfo;
+
+public class EnhancementMultipleParamsExtension2 implements BuildCompatibleExtension {
+
+    @Enhancement(types = SomeBean.class)
+    public void enhance(ClassConfig cc, MethodConfig mc, FieldInfo fi) {
+        // no-op deployment should fail
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementMultipleParamsTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementMultipleParamsTest.java
@@ -1,0 +1,17 @@
+package org.jboss.cdi.tck.tests.build.compatible.extensions.invalid;
+
+import jakarta.enterprise.inject.spi.DefinitionException;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.ShouldThrowException;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.test.audit.annotations.SpecVersion;
+
+@SpecVersion(spec = "cdi", version = "4.0")
+public class EnhancementMultipleParamsTest extends AbstractInvalidExtensionParamTest {
+
+    @ShouldThrowException(DefinitionException.class)
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return prepareArchiveBuilder().withBuildCompatibleExtension(EnhancementMultipleParamsExtension.class).build();
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementNoParamExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementNoParamExtension.java
@@ -1,0 +1,14 @@
+package org.jboss.cdi.tck.tests.build.compatible.extensions.invalid;
+
+import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;
+import jakarta.enterprise.inject.build.compatible.spi.Enhancement;
+import org.jboss.test.audit.annotations.SpecVersion;
+
+@SpecVersion(spec = "cdi", version = "4.0")
+public class EnhancementNoParamExtension implements BuildCompatibleExtension {
+
+    @Enhancement(types = SomeBean.class)
+    public void enhance() {
+        // no-op deployment should fail
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementNoParamTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementNoParamTest.java
@@ -1,0 +1,17 @@
+package org.jboss.cdi.tck.tests.build.compatible.extensions.invalid;
+
+import jakarta.enterprise.inject.spi.DefinitionException;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.ShouldThrowException;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.test.audit.annotations.SpecVersion;
+
+@SpecVersion(spec = "cdi", version = "4.0")
+public class EnhancementNoParamTest extends AbstractInvalidExtensionParamTest {
+
+    @ShouldThrowException(DefinitionException.class)
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return prepareArchiveBuilder().withBuildCompatibleExtension(EnhancementNoParamExtension.class).build();
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementOnlyMessagesExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementOnlyMessagesExtension.java
@@ -1,0 +1,13 @@
+package org.jboss.cdi.tck.tests.build.compatible.extensions.invalid;
+
+import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;
+import jakarta.enterprise.inject.build.compatible.spi.Enhancement;
+import jakarta.enterprise.inject.build.compatible.spi.Messages;
+
+public class EnhancementOnlyMessagesExtension implements BuildCompatibleExtension {
+
+    @Enhancement(types = SomeBean.class)
+    public void enhance(Messages msg) {
+        // no-op deployment should fail
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementOnlyMessagesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementOnlyMessagesTest.java
@@ -1,0 +1,17 @@
+package org.jboss.cdi.tck.tests.build.compatible.extensions.invalid;
+
+import jakarta.enterprise.inject.spi.DefinitionException;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.ShouldThrowException;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.test.audit.annotations.SpecVersion;
+
+@SpecVersion(spec = "cdi", version = "4.0")
+public class EnhancementOnlyMessagesTest extends AbstractInvalidExtensionParamTest {
+
+    @ShouldThrowException(DefinitionException.class)
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return prepareArchiveBuilder().withBuildCompatibleExtension(EnhancementOnlyMessagesExtension.class).build();
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementOnlyTypesExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementOnlyTypesExtension.java
@@ -1,0 +1,13 @@
+package org.jboss.cdi.tck.tests.build.compatible.extensions.invalid;
+
+import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;
+import jakarta.enterprise.inject.build.compatible.spi.Enhancement;
+import jakarta.enterprise.inject.build.compatible.spi.Types;
+
+public class EnhancementOnlyTypesExtension implements BuildCompatibleExtension {
+
+    @Enhancement(types = SomeBean.class)
+    public void enhance(Types types) {
+        // no-op deployment should fail
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementOnlyTypesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementOnlyTypesTest.java
@@ -1,0 +1,17 @@
+package org.jboss.cdi.tck.tests.build.compatible.extensions.invalid;
+
+import jakarta.enterprise.inject.spi.DefinitionException;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.ShouldThrowException;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.test.audit.annotations.SpecVersion;
+
+@SpecVersion(spec = "cdi", version = "4.0")
+public class EnhancementOnlyTypesTest extends AbstractInvalidExtensionParamTest {
+
+    @ShouldThrowException(DefinitionException.class)
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return prepareArchiveBuilder().withBuildCompatibleExtension(EnhancementOnlyTypesExtension.class).build();
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationMultipleParams2Test.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationMultipleParams2Test.java
@@ -1,0 +1,17 @@
+package org.jboss.cdi.tck.tests.build.compatible.extensions.invalid;
+
+import jakarta.enterprise.inject.spi.DefinitionException;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.ShouldThrowException;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.test.audit.annotations.SpecVersion;
+
+@SpecVersion(spec = "cdi", version = "4.0")
+public class RegistrationMultipleParams2Test extends AbstractInvalidExtensionParamTest {
+
+    @ShouldThrowException(DefinitionException.class)
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return prepareArchiveBuilder().withBuildCompatibleExtension(RegistrationMultipleParamsExtension2.class).build();
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationMultipleParamsExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationMultipleParamsExtension.java
@@ -1,0 +1,14 @@
+package org.jboss.cdi.tck.tests.build.compatible.extensions.invalid;
+
+import jakarta.enterprise.inject.build.compatible.spi.BeanInfo;
+import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;
+import jakarta.enterprise.inject.build.compatible.spi.InterceptorInfo;
+import jakarta.enterprise.inject.build.compatible.spi.Registration;
+
+public class RegistrationMultipleParamsExtension implements BuildCompatibleExtension {
+
+    @Registration(types = {SomeBean.class})
+    public void register(BeanInfo bi, InterceptorInfo ii) {
+        // no-op, deployment should fail
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationMultipleParamsExtension2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationMultipleParamsExtension2.java
@@ -1,0 +1,15 @@
+package org.jboss.cdi.tck.tests.build.compatible.extensions.invalid;
+
+import jakarta.enterprise.inject.build.compatible.spi.BeanInfo;
+import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;
+import jakarta.enterprise.inject.build.compatible.spi.ObserverInfo;
+import jakarta.enterprise.inject.build.compatible.spi.Registration;
+import jakarta.enterprise.inject.build.compatible.spi.Types;
+
+public class RegistrationMultipleParamsExtension2 implements BuildCompatibleExtension {
+
+    @Registration(types = {SomeBean.class})
+    public void register(ObserverInfo oi, Types t, BeanInfo bi) {
+        // no-op, deployment should fail
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationMultipleParamsTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationMultipleParamsTest.java
@@ -1,0 +1,17 @@
+package org.jboss.cdi.tck.tests.build.compatible.extensions.invalid;
+
+import jakarta.enterprise.inject.spi.DefinitionException;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.ShouldThrowException;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.test.audit.annotations.SpecVersion;
+
+@SpecVersion(spec = "cdi", version = "4.0")
+public class RegistrationMultipleParamsTest extends AbstractInvalidExtensionParamTest {
+
+    @ShouldThrowException(DefinitionException.class)
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return prepareArchiveBuilder().withBuildCompatibleExtension(RegistrationMultipleParamsExtension.class).build();
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationNoParamExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationNoParamExtension.java
@@ -1,0 +1,12 @@
+package org.jboss.cdi.tck.tests.build.compatible.extensions.invalid;
+
+import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;
+import jakarta.enterprise.inject.build.compatible.spi.Registration;
+
+public class RegistrationNoParamExtension implements BuildCompatibleExtension {
+
+    @Registration(types = {SomeBean.class})
+    public void register() {
+        // no-op, deployment should fail
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationNoParamTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationNoParamTest.java
@@ -1,0 +1,17 @@
+package org.jboss.cdi.tck.tests.build.compatible.extensions.invalid;
+
+import jakarta.enterprise.inject.spi.DefinitionException;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.ShouldThrowException;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.test.audit.annotations.SpecVersion;
+
+@SpecVersion(spec = "cdi", version = "4.0")
+public class RegistrationNoParamTest extends AbstractInvalidExtensionParamTest {
+
+    @ShouldThrowException(DefinitionException.class)
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return prepareArchiveBuilder().withBuildCompatibleExtension(RegistrationNoParamExtension.class).build();
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationOnlyMessagesExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationOnlyMessagesExtension.java
@@ -1,0 +1,13 @@
+package org.jboss.cdi.tck.tests.build.compatible.extensions.invalid;
+
+import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;
+import jakarta.enterprise.inject.build.compatible.spi.Messages;
+import jakarta.enterprise.inject.build.compatible.spi.Registration;
+
+public class RegistrationOnlyMessagesExtension implements BuildCompatibleExtension {
+
+    @Registration(types = {SomeBean.class})
+    public void register(Messages m) {
+        // no-op, deployment should fail
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationOnlyMessagesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationOnlyMessagesTest.java
@@ -1,0 +1,17 @@
+package org.jboss.cdi.tck.tests.build.compatible.extensions.invalid;
+
+import jakarta.enterprise.inject.spi.DefinitionException;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.ShouldThrowException;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.test.audit.annotations.SpecVersion;
+
+@SpecVersion(spec = "cdi", version = "4.0")
+public class RegistrationOnlyMessagesTest extends AbstractInvalidExtensionParamTest {
+
+    @ShouldThrowException(DefinitionException.class)
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return prepareArchiveBuilder().withBuildCompatibleExtension(RegistrationOnlyMessagesExtension.class).build();
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationOnlyTypesExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationOnlyTypesExtension.java
@@ -1,0 +1,13 @@
+package org.jboss.cdi.tck.tests.build.compatible.extensions.invalid;
+
+import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;
+import jakarta.enterprise.inject.build.compatible.spi.Registration;
+import jakarta.enterprise.inject.build.compatible.spi.Types;
+
+public class RegistrationOnlyTypesExtension implements BuildCompatibleExtension {
+
+    @Registration(types = {SomeBean.class})
+    public void register(Types t) {
+        // no-op, deployment should fail
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationOnlyTypesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationOnlyTypesTest.java
@@ -1,0 +1,17 @@
+package org.jboss.cdi.tck.tests.build.compatible.extensions.invalid;
+
+import jakarta.enterprise.inject.spi.DefinitionException;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.ShouldThrowException;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.test.audit.annotations.SpecVersion;
+
+@SpecVersion(spec = "cdi", version = "4.0")
+public class RegistrationOnlyTypesTest extends AbstractInvalidExtensionParamTest {
+
+    @ShouldThrowException(DefinitionException.class)
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return prepareArchiveBuilder().withBuildCompatibleExtension(RegistrationOnlyTypesExtension.class).build();
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/SomeBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/SomeBean.java
@@ -1,0 +1,8 @@
+package org.jboss.cdi.tck.tests.build.compatible.extensions.invalid;
+
+import jakarta.enterprise.context.Dependent;
+
+// Dummy bean class just to have some in the bean archive
+@Dependent
+public class SomeBean {
+}


### PR DESCRIPTION
…d parameter combinations.

Fixes #321 

Adds ten tests for various invalid combinations of parameters in `@Enhancement` and `@Registration` phases.

@Ladicek all tests are expecting a `DefinitionException` - I originally wanted to do deployment exception (as we said in spec, see https://github.com/eclipse-ee4j/cdi/commit/7b085ac47cd7477f54f7c6baffc846a4d2733179) but I ended up thinking it's really a definition issue. I can change the spec wording accordingly if we agree on it.