### PR TITLE
Change lang model TCKs to pass on both, JDK 11 and 17 if using reflec…

### DIFF
--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/AnnotatedTypes.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/AnnotatedTypes.java
@@ -634,10 +634,13 @@ public class AnnotatedTypes<@AnnTypeVariableClass1 A,
         assert field.type().asTypeVariable().name().equals("B");
         assert field.type().asTypeVariable().bounds().size() == 1;
         assert field.type().asTypeVariable().bounds().get(0).isTypeVariable();
-        TypeVariable ftype = field.type().asTypeVariable();
-        Type bound0 = ftype.bounds().get(0);
-        Collection<AnnotationInfo> annotations = bound0.annotations();
-        assert field.type().asTypeVariable().bounds().get(0).asTypeVariable().annotations().isEmpty();
+        // JDK 11 and JDK 17, when accessed through reflection, disagree on annotations declared on generic bounds; TCK accepts both variants
+        Collection<AnnotationInfo> annotationInfos = field.type().asTypeVariable().bounds().get(0).asTypeVariable().annotations();
+        assert annotationInfos.isEmpty() || annotationInfos.size() == 1; // JDK 11 reflection doesn't see any annotation
+        if (annotationInfos.size() == 1) {
+            // JDK 17 reflection correctly recognizes one annotation
+            assert field.type().asTypeVariable().bounds().get(0).asTypeVariable().hasAnnotation(AnnTypeVariableClass3.class);
+        }
         assert field.type().asTypeVariable().bounds().get(0).asTypeVariable().name().equals("A");
         assert field.type().asTypeVariable().bounds().get(0).asTypeVariable().bounds().size() == 1;
         assert field.type().asTypeVariable().bounds().get(0).asTypeVariable().bounds().get(0).isClass();


### PR DESCRIPTION
…tion as basis for lang model.

Fixes #330 


Adapted the TCK to pass for both JDK versions that I tested with (11,17).

There is probably going to be more weirdness with other JDKs, but I haven't tested them all.
For instance I have noticed a discrepancy between JDK 11 and JDK 17 in how they handle annotated Enum constructor parameters (apparently, JDK 11 moves all your annotations over to a synthetic parameter??!). I am thinking maybe we should state what JDK is the lang model supposed to be tested with for purposes of compatibility (i.e. JDK 11 for EE 10) and then review for every major JDK release. That, or we need to make sure we try it with every JDK version that's out and keep iterating on it which might be expensive.

I'm open to suggestions.
Also CCing @Ladicek - would love to hear your thoughts on this once you're back.