### PR TITLE
Add a section on the CDI Lite signature test requirements

### DIFF
--- a/doc/reference/src/main/asciidoc/sigtest.asciidoc
+++ b/doc/reference/src/main/asciidoc/sigtest.asciidoc
@@ -248,6 +248,9 @@ https://github.com/eclipse-ee4j/cdi-tck/blob/master/impl/src/main/resources/sigt
 </project>
 ----
 
+=== CDI Lite Signature Tests
+CDI Lite requires the same signature tests as Full. Even though CDI Lite does not require some of the Jakarta Interceptors behaviors, we did not want to restrict what CDI Lite implementations might provide in the way of interceptors, for example, an implementation that supports for Lite and Full. An implementation of CDI Lite can simply depend on the Jakarta Interceptors API artifact to meet the signature test requirements.
+
 === Forcing a signature test failure
 
 Just for fun (and to confirm that the signature test is working correctly), you can try the following:

--- a/doc/reference/src/main/asciidoc/sigtest.asciidoc
+++ b/doc/reference/src/main/asciidoc/sigtest.asciidoc
@@ -249,7 +249,7 @@ https://github.com/eclipse-ee4j/cdi-tck/blob/master/impl/src/main/resources/sigt
 ----
 
 === CDI Lite Signature Tests
-CDI Lite requires the same signature tests as Full. Even though CDI Lite does not require some of the Jakarta Interceptors behaviors, we did not want to restrict what CDI Lite implementations might provide in the way of interceptors, for example, an implementation that supports for Lite and Full. An implementation of CDI Lite can simply depend on the Jakarta Interceptors API artifact to meet the signature test requirements.
+CDI Lite requires the same signature tests as Full. Even though CDI Lite does not require some of the Jakarta Interceptors behaviors, we did not want to restrict what CDI Lite implementations might provide in the way of interceptors, for example, an implementation that supports both Lite and Full. An implementation of CDI Lite can simply depend on the Jakarta Interceptors API artifact to meet the signature test requirements.
 
 === Forcing a signature test failure
 


### PR DESCRIPTION
As discussed on the CDI call today, add a statement regarding the CDI Lite signature test requirements being the same as Full.

Signed-off-by: Scott M Stark <starksm64@gmail.com>