### PR TITLE
Introduce tests for Startup/Shutdown, revert versions

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/lifecycle/ObservingBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/lifecycle/ObservingBean.java
@@ -1,0 +1,34 @@
+package org.jboss.cdi.tck.tests.event.lifecycle;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.BeforeDestroyed;
+import jakarta.enterprise.context.Initialized;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.event.Shutdown;
+import jakarta.enterprise.event.Startup;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@ApplicationScoped
+public class ObservingBean {
+
+    public static List<String> OBSERVED_STARTING_EVENTS = new ArrayList<>();
+    public static List<String> OBSERVED_SHUTDOWN_EVENTS = new ArrayList<>();
+
+    public void startup(@Observes Startup startup) {
+        OBSERVED_STARTING_EVENTS.add(Startup.class.getSimpleName());
+    }
+
+    public void initAppScope(@Observes @Initialized(ApplicationScoped.class) Object init) {
+        OBSERVED_STARTING_EVENTS.add(ApplicationScoped.class.getSimpleName());
+    }
+
+    public void shutdown(@Observes Shutdown shutdown) {
+        OBSERVED_SHUTDOWN_EVENTS.add(Shutdown.class.getSimpleName());
+    }
+
+    public void observeBeforeShutdown(@Observes @BeforeDestroyed(ApplicationScoped.class) Object event) {
+        OBSERVED_SHUTDOWN_EVENTS.add(ApplicationScoped.class.getSimpleName());
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/lifecycle/StartupShutdownTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/lifecycle/StartupShutdownTest.java
@@ -1,0 +1,41 @@
+package org.jboss.cdi.tck.tests.event.lifecycle;
+
+import static org.jboss.cdi.tck.cdi.Sections.BUILTIN_EVENT;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Startup;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.cdi.tck.AbstractTest;
+import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.test.audit.annotations.SpecVersion;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Tests {@link jakarta.enterprise.event.Startup} event. The test also uses {@link jakarta.enterprise.event.Shutdown}
+ * but we cannot make assertion on it because the entirety of the test happens inside running CDI container.
+ *
+ * Note that there is also {@link org.jboss.cdi.tck.tests.se.events.lifecycle.StartupShutdownTest} which tests
+ * both events under CDI SE.
+ */
+@SpecVersion(spec = "cdi", version = "4.0")
+public class StartupShutdownTest extends AbstractTest {
+
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return new WebArchiveBuilder().withTestClassPackage(StartupShutdownTest.class).build();
+    }
+
+    @Test
+    //@SpecAssertion(section = TODO, id = "TODO")
+    public void testEventsObserved() {
+        Assert.assertTrue(ObservingBean.OBSERVED_STARTING_EVENTS.size() == 2);
+        Assert.assertTrue(ObservingBean.OBSERVED_STARTING_EVENTS.get(0).equals(ApplicationScoped.class.getSimpleName()));
+        Assert.assertTrue(ObservingBean.OBSERVED_STARTING_EVENTS.get(1).equals(Startup.class.getSimpleName()));
+
+        // Note that we cannot assert that shutdown event was invoked because entirety of this test class
+        // happens before shutdown
+        Assert.assertTrue(ObservingBean.OBSERVED_SHUTDOWN_EVENTS.isEmpty());
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/events/lifecycle/ObservingBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/events/lifecycle/ObservingBean.java
@@ -1,0 +1,34 @@
+package org.jboss.cdi.tck.tests.se.events.lifecycle;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.BeforeDestroyed;
+import jakarta.enterprise.context.Initialized;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.event.Shutdown;
+import jakarta.enterprise.event.Startup;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@ApplicationScoped
+public class ObservingBean {
+
+    public static List<String> OBSERVED_STARTING_EVENTS = new ArrayList<>();
+    public static List<String> OBSERVED_SHUTDOWN_EVENTS = new ArrayList<>();
+
+    public void startup(@Observes Startup startup) {
+        OBSERVED_STARTING_EVENTS.add(Startup.class.getSimpleName());
+    }
+
+    public void initAppScope(@Observes @Initialized(ApplicationScoped.class) Object init) {
+        OBSERVED_STARTING_EVENTS.add(ApplicationScoped.class.getSimpleName());
+    }
+
+    public void shutdown(@Observes Shutdown shutdown) {
+        OBSERVED_SHUTDOWN_EVENTS.add(Shutdown.class.getSimpleName());
+    }
+
+    public void observeBeforeShutdown(@Observes @BeforeDestroyed(ApplicationScoped.class) Object event) {
+        OBSERVED_SHUTDOWN_EVENTS.add(ApplicationScoped.class.getSimpleName());
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/events/lifecycle/StartupShutdownTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/events/lifecycle/StartupShutdownTest.java
@@ -1,0 +1,55 @@
+package org.jboss.cdi.tck.tests.se.events.lifecycle;
+
+import static org.jboss.cdi.tck.TestGroups.SE;
+import static org.jboss.cdi.tck.cdi.Sections.BEAN_ARCHIVE_SE;
+import static org.jboss.cdi.tck.cdi.Sections.SE_BOOTSTRAP;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Shutdown;
+import jakarta.enterprise.event.Startup;
+import jakarta.enterprise.inject.se.SeContainer;
+import jakarta.enterprise.inject.se.SeContainerInitializer;
+import org.jboss.arquillian.container.se.api.ClassPath;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.test.audit.annotations.SpecVersion;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Tests {@link jakarta.enterprise.event.Startup} and {@link jakarta.enterprise.event.Shutdown} event delivery.
+ * The reason we test this in SE container is that we can make assertions on both of these events as the test
+ * spans even beyond the CDI container lifecycle.
+ */
+@Test(groups = SE)
+@SpecVersion(spec = "cdi", version = "4.0")
+public class StartupShutdownTest {
+
+    @Deployment
+    public static Archive<?> createTestArchive() {
+        return ClassPath.builder().add(ShrinkWrap.create(JavaArchive.class)
+                .addPackage(StartupShutdownTest.class.getPackage())).build();
+    }
+
+    @Test
+    // @SpecAssertion(section = TODO, id = "TODO")
+    public void testEvents() {
+        // assert initial state
+        Assert.assertTrue(ObservingBean.OBSERVED_STARTING_EVENTS.isEmpty());
+        Assert.assertTrue(ObservingBean.OBSERVED_SHUTDOWN_EVENTS.isEmpty());
+
+        try (SeContainer seContainer = SeContainerInitializer.newInstance().addBeanClasses(ObservingBean.class).initialize()) {
+            Assert.assertTrue(ObservingBean.OBSERVED_STARTING_EVENTS.size() == 2);
+            Assert.assertTrue(ObservingBean.OBSERVED_STARTING_EVENTS.get(0).equals(ApplicationScoped.class.getSimpleName()));
+            Assert.assertTrue(ObservingBean.OBSERVED_STARTING_EVENTS.get(1).equals(Startup.class.getSimpleName()));
+        }
+
+        // we can only assert these events after we shutdown Weld container
+        Assert.assertTrue(ObservingBean.OBSERVED_SHUTDOWN_EVENTS.size() == 2);
+        Assert.assertTrue(ObservingBean.OBSERVED_SHUTDOWN_EVENTS.get(0).equals(Shutdown.class.getSimpleName()));
+        Assert.assertTrue(ObservingBean.OBSERVED_SHUTDOWN_EVENTS.get(1).equals(ApplicationScoped.class.getSimpleName()));
+
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -97,13 +97,13 @@
 
     <properties>
         <!-- CDI API -->
-        <cdi.api.version>4.0.0</cdi.api.version>
+        <cdi.api.version>4.0.0-RC5</cdi.api.version>
         <maven.compiler.release>11</maven.compiler.release>
         <!-- Jakarta EE APIs Core -->
-        <annotations.api.version>2.1.0</annotations.api.version>
-        <interceptors.api.version>2.1.0</interceptors.api.version>
+        <annotations.api.version>2.1.0-B1</annotations.api.version>
+        <interceptors.api.version>2.1.0-RC3</interceptors.api.version>
         <atinject.api.version>2.0.1</atinject.api.version>
-        <el.api.version>5.0.0</el.api.version>
+        <el.api.version>5.0.0-RC1</el.api.version>
 
         <!-- Test tools/dependencies -->
         <testng.version>7.4.0</testng.version>


### PR DESCRIPTION
Fixes #353 

Similar to tests I've added to Weld.
In classic test, we are unable to verify `Shutdown` event but there is also an SE test where both can be verified just fine.

I have also added a commit that reverts versions back to latest released so that we can have a pass in CI and release new RC (which I'll do, likely tomorrow).