### PR TITLE
Change the scope of bean housing observer to an always active scope

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/instance/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/instance/Bar.java
@@ -17,11 +17,11 @@
 
 package org.jboss.cdi.tck.tests.context.dependent.instance;
 
-import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.Instance;
 
-@RequestScoped
+@ApplicationScoped
 public class Bar {
 
     public void observeGoodEvents(Instance<Foo> instance, @Observes GoodEvent goodEvent) {


### PR DESCRIPTION
Fixes #357 