### PR TITLE
Make BCE invalid tests include extension class

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementMultipleParams2Test.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementMultipleParams2Test.java
@@ -12,6 +12,8 @@ public class EnhancementMultipleParams2Test extends AbstractInvalidExtensionPara
     @ShouldThrowException(DefinitionException.class)
     @Deployment
     public static WebArchive createTestArchive() {
-        return prepareArchiveBuilder().withBuildCompatibleExtension(EnhancementMultipleParamsExtension2.class).build();
+        return prepareArchiveBuilder().withBuildCompatibleExtension(EnhancementMultipleParamsExtension2.class)
+                                      .withClass(EnhancementMultipleParamsExtension2.class)
+                                      .build();
     }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementMultipleParamsTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementMultipleParamsTest.java
@@ -12,6 +12,8 @@ public class EnhancementMultipleParamsTest extends AbstractInvalidExtensionParam
     @ShouldThrowException(DefinitionException.class)
     @Deployment
     public static WebArchive createTestArchive() {
-        return prepareArchiveBuilder().withBuildCompatibleExtension(EnhancementMultipleParamsExtension.class).build();
+        return prepareArchiveBuilder().withBuildCompatibleExtension(EnhancementMultipleParamsExtension.class)
+                                      .withClass(EnhancementMultipleParamsExtension.class)
+                                      .build();
     }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementNoParamTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementNoParamTest.java
@@ -12,6 +12,8 @@ public class EnhancementNoParamTest extends AbstractInvalidExtensionParamTest {
     @ShouldThrowException(DefinitionException.class)
     @Deployment
     public static WebArchive createTestArchive() {
-        return prepareArchiveBuilder().withBuildCompatibleExtension(EnhancementNoParamExtension.class).build();
+        return prepareArchiveBuilder().withBuildCompatibleExtension(EnhancementNoParamExtension.class)
+                                      .withClass(EnhancementNoParamExtension.class)
+                                      .build();
     }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementOnlyMessagesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementOnlyMessagesTest.java
@@ -12,6 +12,8 @@ public class EnhancementOnlyMessagesTest extends AbstractInvalidExtensionParamTe
     @ShouldThrowException(DefinitionException.class)
     @Deployment
     public static WebArchive createTestArchive() {
-        return prepareArchiveBuilder().withBuildCompatibleExtension(EnhancementOnlyMessagesExtension.class).build();
+        return prepareArchiveBuilder().withBuildCompatibleExtension(EnhancementOnlyMessagesExtension.class)
+                                      .withClass(EnhancementOnlyMessagesExtension.class)
+                                      .build();
     }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementOnlyTypesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementOnlyTypesTest.java
@@ -12,6 +12,8 @@ public class EnhancementOnlyTypesTest extends AbstractInvalidExtensionParamTest 
     @ShouldThrowException(DefinitionException.class)
     @Deployment
     public static WebArchive createTestArchive() {
-        return prepareArchiveBuilder().withBuildCompatibleExtension(EnhancementOnlyTypesExtension.class).build();
+        return prepareArchiveBuilder().withBuildCompatibleExtension(EnhancementOnlyTypesExtension.class)
+                                      .withClass(EnhancementOnlyTypesExtension.class)
+                                      .build();
     }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationMultipleParams2Test.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationMultipleParams2Test.java
@@ -12,6 +12,8 @@ public class RegistrationMultipleParams2Test extends AbstractInvalidExtensionPar
     @ShouldThrowException(DefinitionException.class)
     @Deployment
     public static WebArchive createTestArchive() {
-        return prepareArchiveBuilder().withBuildCompatibleExtension(RegistrationMultipleParamsExtension2.class).build();
+        return prepareArchiveBuilder().withBuildCompatibleExtension(RegistrationMultipleParamsExtension2.class)
+                                      .withClass(RegistrationMultipleParamsExtension2.class)
+                                      .build();
     }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationMultipleParamsTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationMultipleParamsTest.java
@@ -12,6 +12,8 @@ public class RegistrationMultipleParamsTest extends AbstractInvalidExtensionPara
     @ShouldThrowException(DefinitionException.class)
     @Deployment
     public static WebArchive createTestArchive() {
-        return prepareArchiveBuilder().withBuildCompatibleExtension(RegistrationMultipleParamsExtension.class).build();
+        return prepareArchiveBuilder().withBuildCompatibleExtension(RegistrationMultipleParamsExtension.class)
+                                      .withClass(RegistrationMultipleParamsExtension.class)
+                                      .build();
     }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationNoParamTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationNoParamTest.java
@@ -12,6 +12,8 @@ public class RegistrationNoParamTest extends AbstractInvalidExtensionParamTest {
     @ShouldThrowException(DefinitionException.class)
     @Deployment
     public static WebArchive createTestArchive() {
-        return prepareArchiveBuilder().withBuildCompatibleExtension(RegistrationNoParamExtension.class).build();
+        return prepareArchiveBuilder().withBuildCompatibleExtension(RegistrationNoParamExtension.class)
+                        .withClass(RegistrationNoParamExtension.class)
+                        .build();
     }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationOnlyMessagesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationOnlyMessagesTest.java
@@ -12,6 +12,8 @@ public class RegistrationOnlyMessagesTest extends AbstractInvalidExtensionParamT
     @ShouldThrowException(DefinitionException.class)
     @Deployment
     public static WebArchive createTestArchive() {
-        return prepareArchiveBuilder().withBuildCompatibleExtension(RegistrationOnlyMessagesExtension.class).build();
+        return prepareArchiveBuilder().withBuildCompatibleExtension(RegistrationOnlyMessagesExtension.class)
+                        .withClass(RegistrationOnlyMessagesExtension.class)
+                        .build();
     }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationOnlyTypesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationOnlyTypesTest.java
@@ -12,6 +12,8 @@ public class RegistrationOnlyTypesTest extends AbstractInvalidExtensionParamTest
     @ShouldThrowException(DefinitionException.class)
     @Deployment
     public static WebArchive createTestArchive() {
-        return prepareArchiveBuilder().withBuildCompatibleExtension(RegistrationOnlyTypesExtension.class).build();
+        return prepareArchiveBuilder().withBuildCompatibleExtension(RegistrationOnlyTypesExtension.class)
+                        .withClass(RegistrationOnlyTypesExtension.class)
+                        .build();
     }
 }


### PR DESCRIPTION
Previously, the test was adding the service provider file but not the
actual extension class.

Fixes #359 