### PR TITLE
IntrospectServlet needs to be a bean for JEEComponentTest

### DIFF
--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/ee/components/IntrospectServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/ee/components/IntrospectServlet.java
@@ -44,6 +44,7 @@ import org.jboss.cdi.tck.util.ActionSequence;
  */
 @SuppressWarnings("serial")
 @WebServlet("/test")
+@Dependent
 public class IntrospectServlet extends HttpServlet {
 
     public static final String MODE_INJECT = "inject";


### PR DESCRIPTION
This used to be a bean because we used discovery mode all. However, the
default discovery mode has changed in 4.0 to be annotated, so the class
needs an annotation to be a bean.

Fixes #361 