### PR TITLE
Revert change to InvalidatingSessionDestroysConversationTest

### DIFF
--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/InvalidatingSessionDestroysConversationTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/InvalidatingSessionDestroysConversationTest.java
@@ -60,7 +60,7 @@ public class InvalidatingSessionDestroysConversationTest extends AbstractConvers
         WebClient webClient = new WebClient();
 
         resetCloud(webClient);
-        webClient.getPage(getPath("clouds.xhtml"));
+        webClient.getPage(getPath("clouds.jsf"));
 
         assertFalse(isCloudDestroyed(webClient));
         invalidateSession(webClient);


### PR DESCRIPTION
Request clouds.jsf rather than clouds.xhtml so that the request matches
the pattern for the faces servlet.

With this change, I have this test passing on Open Liberty.

Fixes #367 