### PR TITLE
Set discovery-mode=all for non.contextual.ContainerEventTest

### DIFF
--- a/impl/src/main/java/org/jboss/shrinkwrap/impl/BeansXml.java
+++ b/impl/src/main/java/org/jboss/shrinkwrap/impl/BeansXml.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 /**
  * Allows to create a beans.xml file programmatically.
- * By default it uses discovery mode all and has version 3.0
+ * By default it uses discovery mode annotated and has version 3.0
  */
 public class BeansXml implements Asset {
 

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/non/contextual/ContainerEventTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/non/contextual/ContainerEventTest.java
@@ -45,7 +45,9 @@ import jakarta.servlet.jsp.tagext.SimpleTagSupport;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.ee.WebArchiveBuilder;
+import org.jboss.shrinkwrap.api.BeanDiscoveryMode;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.impl.BeansXml;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
@@ -75,6 +77,7 @@ public class ContainerEventTest extends AbstractTest {
                 .withWebResource("TagPage.jsp", "TagPage.jsp").withWebResource("faces-config.xml", "/WEB-INF/faces-config.xml")
                 .withWebResource("TestLibrary.tld", "WEB-INF/TestLibrary.tld")
                 .withDefaultPersistenceXml()
+                .withBeansXml(new BeansXml(BeanDiscoveryMode.ALL))
                 .build();
     }
 


### PR DESCRIPTION
This test relies on unannotated classes being discovered and so needs
discovery-mode=all.

This now needs to be added explicitly because the default was changed to
discovery-mode=annotated.

Also update the BeansXml javadoc with the new default discovery mode.

Fixes #369 