### PR TITLE
withDefaultPersistenceXml should use deployment time config

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/shrinkwrap/ArchiveBuilder.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/shrinkwrap/ArchiveBuilder.java
@@ -563,7 +563,7 @@ public abstract class ArchiveBuilder<T extends ArchiveBuilder<T, A>, A extends A
      */
     public T withDefaultPersistenceXml() {
         return withPersistenceXml(Descriptors.create(PersistenceDescriptor.class).createPersistenceUnit().name("test")
-                .jtaDataSource(ConfigurationFactory.get().getTestDataSource()).up());
+                .jtaDataSource(ConfigurationFactory.get(true).getTestDataSource()).up());
     }
 
     /**


### PR DESCRIPTION
`withDefaultPersistenceXml` is called in the deployment phase (to build the test application archive) so it should use the deployment time config.

Without this, the TCK expects the porting package and all its dependencies to be present on the test classpath, rather than just on the server. This made it much harder for me to run `ContainerEventTest` on my workstation since the porting package depends on server internals (and I don't think this test needs the porting package anyway).

Although I think this is a bug, it's been present in previous releases so everyone who has passed the older TCKs has clearly managed to work around it so we don't need to rush it in for 4.0.