### PR TITLE
Add TCK coverage for wildcard in Event/Injection injection points

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/wildcard/BeanInjectingInvalidEvent.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/wildcard/BeanInjectingInvalidEvent.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2025, Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.cdi.tck.tests.event.broken.wildcard;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Event;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class BeanInjectingInvalidEvent {
+
+    @Inject
+    Event<? extends String> wildEvent;
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/wildcard/EventWithWildcardTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/wildcard/EventWithWildcardTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025, Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.cdi.tck.tests.event.broken.wildcard;
+
+import jakarta.enterprise.inject.spi.DefinitionException;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.ShouldThrowException;
+import org.jboss.cdi.tck.AbstractTest;
+import org.jboss.cdi.tck.cdi.Sections;
+import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.test.audit.annotations.SpecAssertion;
+import org.jboss.test.audit.annotations.SpecVersion;
+import org.testng.annotations.Test;
+
+@SpecVersion(spec = "cdi", version = "5.0")
+public class EventWithWildcardTest extends AbstractTest {
+
+    @ShouldThrowException(DefinitionException.class)
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return new WebArchiveBuilder().withTestClass(EventWithWildcardTest.class)
+                .withClasses(BeanInjectingInvalidEvent.class).build();
+    }
+
+    @Test
+    @SpecAssertion(section = Sections.EVENT, id = "eac")
+    public void testEventWildcardIsDetected() {
+        // test should throw an exception
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/broken/wildcard/BeanWithInstanceWithWildcardEvent.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/broken/wildcard/BeanWithInstanceWithWildcardEvent.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025, Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.cdi.tck.tests.lookup.dynamic.broken.wildcard;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Event;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class BeanWithInstanceWithWildcardEvent {
+
+    @Inject
+    Instance<Event<? super String>> veryWildInstance;
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/broken/wildcard/BeanWithWildcardInstance.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/broken/wildcard/BeanWithWildcardInstance.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2025, Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.cdi.tck.tests.lookup.dynamic.broken.wildcard;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class BeanWithWildcardInstance {
+
+    @Inject
+    Instance<? super Integer> wildInstance;
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/broken/wildcard/InstanceWithEventWithWildcardTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/broken/wildcard/InstanceWithEventWithWildcardTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025, Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.cdi.tck.tests.lookup.dynamic.broken.wildcard;
+
+import jakarta.enterprise.inject.spi.DefinitionException;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.ShouldThrowException;
+import org.jboss.cdi.tck.AbstractTest;
+import org.jboss.cdi.tck.cdi.Sections;
+import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
+import org.jboss.cdi.tck.tests.event.broken.wildcard.EventWithWildcardTest;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.test.audit.annotations.SpecAssertion;
+import org.jboss.test.audit.annotations.SpecVersion;
+import org.testng.annotations.Test;
+
+@SpecVersion(spec = "cdi", version = "5.0")
+public class InstanceWithEventWithWildcardTest extends AbstractTest {
+
+    @ShouldThrowException(DefinitionException.class)
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return new WebArchiveBuilder().withTestClass(EventWithWildcardTest.class)
+                .withClasses(BeanWithInstanceWithWildcardEvent.class).build();
+    }
+
+    @Test
+    @SpecAssertion(section = Sections.DYNAMIC_LOOKUP, id = "ca")
+    public void testEventWildcardIsDetected() {
+        // test should throw an exception
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/broken/wildcard/InstanceWithWildcardTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/broken/wildcard/InstanceWithWildcardTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025, Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.cdi.tck.tests.lookup.dynamic.broken.wildcard;
+
+import jakarta.enterprise.inject.spi.DefinitionException;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.ShouldThrowException;
+import org.jboss.cdi.tck.AbstractTest;
+import org.jboss.cdi.tck.cdi.Sections;
+import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
+import org.jboss.cdi.tck.tests.event.broken.wildcard.EventWithWildcardTest;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.test.audit.annotations.SpecAssertion;
+import org.jboss.test.audit.annotations.SpecVersion;
+import org.testng.annotations.Test;
+
+@SpecVersion(spec = "cdi", version = "5.0")
+public class InstanceWithWildcardTest extends AbstractTest {
+
+    @ShouldThrowException(DefinitionException.class)
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return new WebArchiveBuilder().withTestClass(EventWithWildcardTest.class)
+                .withClasses(BeanWithWildcardInstance.class).build();
+    }
+
+    @Test
+    @SpecAssertion(section = Sections.DYNAMIC_LOOKUP, id = "ca")
+    public void testEventWildcardIsDetected() {
+        // test should throw an exception
+    }
+}

--- a/impl/src/main/resources/tck-audit-cdi.xml
+++ b/impl/src/main/resources/tck-audit-cdi.xml
@@ -3221,6 +3221,13 @@
             </text>
         </assertion>
 
+        <assertion id="ca">
+            <text>The required type must not be a wildcard type.
+                If an injected |Instance| has a required type that is either a wildcard type or an |Event| whose specified type is a wildcard type, the container treats it as a definition error.
+                If a programmatically obtained |Instance| has a required type that is a wildcard type, non-portable behavior results.
+            </text>
+        </assertion>
+
         <assertion id="da">
             <text>If two instances of the same non repeating qualifier type are passed to |select()|, an |IllegalArgumentException| is thrown.</text>
         </assertion>
@@ -5328,6 +5335,12 @@
 
         <assertion id="eab">
             <text>If the specified type contains a type variable, an |IllegalArgumentException| is thrown.</text>
+        </assertion>
+
+        <assertion id="eac">
+            <text>The specified type must not be a wildcard type.
+                If an injected |Event| has a specified type that is a wildcard type, the container treats it as a definition error.
+                If a programmatically obtained |Event| has a specified type that is a wildcard type, non-portable behavior results..</text>
         </assertion>
 
         <assertion id="eba">


### PR DESCRIPTION
Fixes #641 

I did not go into testing every wildcard variant (plain wildcard, upper/lower bound) as that seems an overkill but I can of course be convinced otherwise.