### PR TITLE
improve annotations and types assertions

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/AbstractTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/AbstractTest.java
@@ -15,13 +15,7 @@ package org.jboss.cdi.tck;
 
 import java.io.IOException;
 import java.lang.annotation.Annotation;
-import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import jakarta.enterprise.context.spi.Context;
@@ -114,49 +108,6 @@ public abstract class AbstractTest extends Arquillian {
         return ConfigurationFactory.get();
     }
 
-    /**
-     * Checks if all annotations are in a given set of annotations
-     *
-     * @param annotations The annotation set
-     * @param requiredAnnotationTypes The annotations to match
-     * @return True if match, false otherwise
-     */
-    protected boolean annotationSetMatches(Set<? extends Annotation> annotations,
-            Class<? extends Annotation>... requiredAnnotationTypes) {
-        Set<Class<? extends Annotation>> annotationsTypeSet = new HashSet<Class<? extends Annotation>>();
-        for (Annotation annotation : annotations) {
-            annotationsTypeSet.add(annotation.annotationType());
-        }
-        return typeSetMatches(annotationsTypeSet, requiredAnnotationTypes);
-    }
-
-    /**
-     * @param annotations The annotation set
-     * @param requiredAnnotations The required annotations
-     * @return <code>true</code> if the specified set matches required annotations, <code>false</code> otherwise
-     */
-    protected boolean annotationSetMatches(Set<? extends Annotation> annotations, Annotation... requiredAnnotations) {
-        List<Annotation> requiredAnnotationList = new ArrayList<Annotation>();
-        return requiredAnnotations.length == annotations.size() && annotations.containsAll(requiredAnnotationList);
-    }
-
-    protected boolean rawTypeSetMatches(Set<Type> types, Class<?>... requiredTypes) {
-        Set<Type> typesRawSet = new HashSet<Type>();
-        for (Type type : types) {
-            if (type instanceof Class<?>) {
-                typesRawSet.add(type);
-            } else if (type instanceof ParameterizedType) {
-                typesRawSet.add(((ParameterizedType) type).getRawType());
-            }
-        }
-        return typeSetMatches(typesRawSet, requiredTypes);
-    }
-
-    protected boolean typeSetMatches(Collection<? extends Type> types, Type... requiredTypes) {
-        List<Type> typeList = Arrays.asList(requiredTypes);
-        return requiredTypes.length == types.size() && types.containsAll(typeList);
-    }
-
     protected <T> Bean<T> getUniqueBean(Class<T> type, Annotation... bindings) {
         Set<Bean<T>> beans = getBeans(type, bindings);
         return resolveUniqueBean(type, beans);
@@ -194,7 +145,7 @@ public abstract class AbstractTest extends Arquillian {
     }
 
     private <T> Bean<T> resolveUniqueBean(Type type, Set<Bean<T>> beans) {
-        if (beans.size() == 0) {
+        if (beans.isEmpty()) {
             throw new UnsatisfiedResolutionException("Unable to resolve any beans of " + type);
         } else if (beans.size() > 1) {
             throw new AmbiguousResolutionException("More than one bean available (" + beans + ")");

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/BeanContainerTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/BeanContainerTest.java
@@ -19,6 +19,7 @@ import static org.jboss.cdi.tck.cdi.Sections.BM_DETERMINING_ANNOTATION;
 import static org.jboss.cdi.tck.cdi.Sections.BM_OBTAIN_CONTEXTS;
 import static org.jboss.cdi.tck.cdi.Sections.BM_PROXY_UNWRAP;
 import static org.jboss.cdi.tck.cdi.Sections.BM_RESOLVE_AMBIGUOUS_DEP;
+import static org.jboss.cdi.tck.util.Assert.assertTypesMatch;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -81,7 +82,7 @@ public class BeanContainerTest extends AbstractTest {
         Bean<?> bean = getCurrentBeanContainer().resolve(beans);
         assertNotNull(bean);
         assertTrue(bean.isAlternative());
-        assertTrue(typeSetMatches(bean.getTypes(), Food.class, Soy.class, Object.class));
+        assertTypesMatch(bean.getTypes(), Food.class, Soy.class, Object.class);
     }
 
     @Test(expectedExceptions = AmbiguousResolutionException.class)

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/bytype/BeanByTypeTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/bytype/BeanByTypeTest.java
@@ -74,8 +74,8 @@ public class BeanByTypeTest extends AbstractTest {
         Set<Bean<?>> beans = getCurrentBeanContainer().getBeans(Connector.class);
         assertEquals(beans.size(), 2);
         for (Bean<?> bean : beans) {
-            if (!typeSetMatches(bean.getTypes(), Object.class, Connector.class)
-                    && !typeSetMatches(bean.getTypes(), Object.class, Connector.class, AlternativeConnector.class)) {
+            if (!bean.getTypes().equals(Set.of(Object.class, Connector.class))
+                    && !bean.getTypes().equals(Set.of(Object.class, Connector.class, AlternativeConnector.class))) {
                 fail("Unexpected bean types found");
             }
         }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/ManagedBeanTypesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/ManagedBeanTypesTest.java
@@ -15,7 +15,7 @@
 package org.jboss.cdi.tck.tests.definition.bean.types;
 
 import static org.jboss.cdi.tck.cdi.Sections.MANAGED_BEAN_TYPES;
-import static org.jboss.cdi.tck.util.Assert.assertTypeSetMatches;
+import static org.jboss.cdi.tck.util.Assert.assertTypesMatch;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
@@ -53,7 +53,7 @@ public class ManagedBeanTypesTest extends AbstractTest {
         assertNotNull(vultureBean);
         // Object, Animal<Integer>, Bird<String, Integer>, Vulture<Integer>, GriffonVulture
         assertEquals(vultureBean.getTypes().size(), 5);
-        assertTypeSetMatches(vultureBean.getTypes(), Object.class, GriffonVulture.class, new TypeLiteral<Animal<Integer>>() {
+        assertTypesMatch(vultureBean.getTypes(), Object.class, GriffonVulture.class, new TypeLiteral<Animal<Integer>>() {
         }.getType(), new TypeLiteral<Bird<String, Integer>>() {
         }.getType(), new TypeLiteral<Vulture<Integer>>() {
         }.getType());
@@ -63,7 +63,7 @@ public class ManagedBeanTypesTest extends AbstractTest {
         assertNotNull(tigerBean);
         // Object, Animal<String>, Mammal<String>, Tiger
         assertEquals(tigerBean.getTypes().size(), 4);
-        assertTypeSetMatches(tigerBean.getTypes(), Object.class, Tiger.class, new TypeLiteral<Animal<String>>() {
+        assertTypesMatch(tigerBean.getTypes(), Object.class, Tiger.class, new TypeLiteral<Animal<String>>() {
         }.getType(), new TypeLiteral<Mammal<String>>() {
         }.getType());
 
@@ -71,7 +71,7 @@ public class ManagedBeanTypesTest extends AbstractTest {
         Bean<Flock> flockBean = getUniqueBean(Flock.class);
         assertNotNull(flockBean);
         // Object, Flock, Gathering<Vulture<Integer>>, GroupingOfCertainType<Vulture<Integer>>
-        assertTypeSetMatches(flockBean.getTypes(), Object.class, Flock.class, new TypeLiteral<Gathering<Vulture<Integer>>>() {
+        assertTypesMatch(flockBean.getTypes(), Object.class, Flock.class, new TypeLiteral<Gathering<Vulture<Integer>>>() {
         }.getType(), new TypeLiteral<GroupingOfCertainType<Vulture<Integer>>>() {
         }.getType());
     }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/name/NameDefinitionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/name/NameDefinitionTest.java
@@ -21,9 +21,9 @@ import static org.jboss.cdi.tck.cdi.Sections.DEFAULT_NAME;
 import static org.jboss.cdi.tck.cdi.Sections.MANAGED_BEAN_NAME;
 import static org.jboss.cdi.tck.cdi.Sections.NAMED_STEREOTYPE;
 import static org.jboss.cdi.tck.cdi.Sections.STEREOTYPES;
+import static org.jboss.cdi.tck.util.Assert.assertAnnotationsMatch;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
 
 import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Default;
@@ -62,8 +62,7 @@ public class NameDefinitionTest extends AbstractTest {
         String name = "haddock";
         Bean<Haddock> haddock = getUniqueBean(Haddock.class);
         assertEquals(haddock.getName(), name);
-        assertTrue(annotationSetMatches(haddock.getQualifiers(), Any.Literal.INSTANCE, Default.Literal.INSTANCE,
-                NamedLiteral.of(name)));
+        assertAnnotationsMatch(haddock.getQualifiers(), Any.Literal.INSTANCE, Default.Literal.INSTANCE, NamedLiteral.of(name));
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/named/DefaultNamedTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/named/DefaultNamedTest.java
@@ -16,8 +16,8 @@ package org.jboss.cdi.tck.tests.definition.stereotype.named;
 import static org.jboss.cdi.tck.cdi.Sections.DEFAULT_NAME;
 import static org.jboss.cdi.tck.cdi.Sections.NAMED_STEREOTYPE;
 import static org.jboss.cdi.tck.cdi.Sections.STEREOTYPES;
+import static org.jboss.cdi.tck.util.Assert.assertAnnotationsMatch;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
 
 import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Default;
@@ -47,7 +47,7 @@ public class DefaultNamedTest extends AbstractTest {
     public void testStereotypeDeclaringNamed() {
         Bean<FallowDeer> fallowBean = getUniqueBean(FallowDeer.class);
         assertEquals(fallowBean.getName(), "fallowDeer");
-        assertTrue(annotationSetMatches(fallowBean.getQualifiers(), Any.Literal.INSTANCE, Default.Literal.INSTANCE));
+        assertAnnotationsMatch(fallowBean.getQualifiers(), Any.Literal.INSTANCE, Default.Literal.INSTANCE);
     }
 
     @Test
@@ -56,8 +56,7 @@ public class DefaultNamedTest extends AbstractTest {
         // The bean name is overriden by the bean
         Bean<RoeDeer> roeBean = getUniqueBean(RoeDeer.class);
         assertEquals(roeBean.getName(), "roe");
-        assertTrue(annotationSetMatches(roeBean.getQualifiers(), Any.Literal.INSTANCE, Default.Literal.INSTANCE,
-                NamedLiteral.of("roe")));
+        assertAnnotationsMatch(roeBean.getQualifiers(), Any.Literal.INSTANCE, Default.Literal.INSTANCE, NamedLiteral.of("roe"));
     }
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/EventTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/EventTest.java
@@ -22,6 +22,7 @@ import static org.jboss.cdi.tck.cdi.Sections.MULTIPLE_EVENT_QUALIFIERS;
 import static org.jboss.cdi.tck.cdi.Sections.OBSERVERS_METHOD_INVOCATION;
 import static org.jboss.cdi.tck.cdi.Sections.OBSERVER_METHODS;
 import static org.jboss.cdi.tck.cdi.Sections.OBSERVES;
+import static org.jboss.cdi.tck.util.Assert.assertTypesMatch;
 import static org.testng.Assert.assertTrue;
 
 import java.util.ArrayList;
@@ -122,7 +123,7 @@ public class EventTest extends AbstractTest {
     public void testNonStaticObserverMethodInherited() {
         Egg egg = new Egg();
         getCurrentManager().getEvent().select(Egg.class).fire(egg);
-        assertTrue(typeSetMatches(egg.getClassesVisited(), Farmer.class, LazyFarmer.class));
+        assertTypesMatch(egg.getClassesVisited(), Farmer.class, LazyFarmer.class);
     }
 
     @Test
@@ -130,8 +131,8 @@ public class EventTest extends AbstractTest {
     public void testNonStaticObserverMethodIndirectlyInherited() {
         StockPrice price = new StockPrice();
         getCurrentManager().getEvent().select(StockPrice.class).fire(price);
-        assertTrue(typeSetMatches(price.getClassesVisited(), StockWatcher.class, IntermediateStockWatcher.class,
-                IndirectStockWatcher.class));
+        assertTypesMatch(price.getClassesVisited(), StockWatcher.class, IntermediateStockWatcher.class,
+                IndirectStockWatcher.class);
     }
 
     private <E> void eventObjectContainsTypeVariables(ArrayList<E> eventToFire) {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/metadata/EventMetadataTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/metadata/EventMetadataTest.java
@@ -14,7 +14,7 @@
 package org.jboss.cdi.tck.tests.event.metadata;
 
 import static org.jboss.cdi.tck.cdi.Sections.EVENT_METADATA;
-import static org.jboss.cdi.tck.util.Assert.assertAnnotationSetMatches;
+import static org.jboss.cdi.tck.util.Assert.assertAnnotationsMatch;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
@@ -97,7 +97,7 @@ public class EventMetadataTest extends AbstractTest {
             assertNull(metadata.getInjectionPoint());
         }
         assertEquals(metadata.getType(), resolvedType);
-        assertAnnotationSetMatches(metadata.getQualifiers(), qualifiers);
+        assertAnnotationsMatch(metadata.getQualifiers(), qualifiers);
     }
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/metadata/injectionpoint/EventMetadataInjectionPointTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/metadata/injectionpoint/EventMetadataInjectionPointTest.java
@@ -15,7 +15,7 @@ package org.jboss.cdi.tck.tests.event.metadata.injectionpoint;
 
 import static org.jboss.cdi.tck.cdi.Sections.EVENT_METADATA;
 import static org.jboss.cdi.tck.cdi.Sections.INJECTION_POINT;
-import static org.jboss.cdi.tck.util.Assert.assertAnnotationSetMatches;
+import static org.jboss.cdi.tck.util.Assert.assertAnnotationsMatch;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -140,12 +140,12 @@ public class EventMetadataInjectionPointTest extends AbstractTest {
         notifier.fireInfoEvent();
         lastQualifiers = infoObserver.getLastQualifiers();
         assertNotNull(lastQualifiers);
-        assertAnnotationSetMatches(lastQualifiers, Default.class);
+        assertAnnotationsMatch(lastQualifiers, Default.class);
 
         notifier.fireConstructorInfoEvent();
         lastQualifiers = infoObserver.getLastQualifiers();
         assertNotNull(lastQualifiers);
-        assertAnnotationSetMatches(lastQualifiers, Nice.class);
+        assertAnnotationsMatch(lastQualifiers, Nice.class);
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/dependency/builtin/BuiltinBeanPassivationDependencyTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/dependency/builtin/BuiltinBeanPassivationDependencyTest.java
@@ -20,12 +20,15 @@ import static org.testng.Assert.assertNotNull;
 
 import java.io.IOException;
 
+import jakarta.enterprise.inject.spi.Annotated;
+import jakarta.enterprise.inject.spi.AnnotatedMember;
+import jakarta.enterprise.inject.spi.AnnotatedParameter;
+import jakarta.enterprise.inject.spi.AnnotatedType;
 import jakarta.inject.Inject;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
-import org.jboss.cdi.tck.util.Assert;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
@@ -112,7 +115,8 @@ public class BuiltinBeanPassivationDependencyTest extends AbstractTest {
         assertEquals(inspectorCopy.getInjectionPoint().getMember(), inspector.getInjectionPoint().getMember());
 
         // Annotated does not necessarily implement equals()/hashcode() so we need to test the underlying Java reflection object
-        Assert.assertAnnotated(inspectorCopy.getInjectionPoint().getAnnotated(), inspector.getInjectionPoint().getAnnotated());
+        assertEquals(unwrap(inspectorCopy.getInjectionPoint().getAnnotated()),
+                unwrap(inspector.getInjectionPoint().getAnnotated()));
         assertEquals(inspectorCopy.getInjectionPoint().getAnnotated().getBaseType(),
                 inspector.getInjectionPoint().getAnnotated().getBaseType());
         assertEquals(inspectorCopy.getInjectionPoint().getAnnotated().getAnnotations(),
@@ -122,4 +126,15 @@ public class BuiltinBeanPassivationDependencyTest extends AbstractTest {
         assertEquals(inspectorCopy.getInjectionPoint().isTransient(), inspector.getInjectionPoint().isTransient());
     }
 
+    private static Object unwrap(final Annotated annotated) {
+        if (annotated instanceof AnnotatedMember<?> am) {
+            return am.getJavaMember();
+        } else if (annotated instanceof AnnotatedParameter<?> ap) {
+            return ap.getJavaParameter();
+        } else if (annotated instanceof AnnotatedType<?> at) {
+            return at.getJavaClass();
+        } else {
+            throw new UnsupportedOperationException("Unknown Annotated instance: " + annotated);
+        }
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/DecoratorDefinitionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/DecoratorDefinitionTest.java
@@ -23,7 +23,7 @@ import static org.jboss.cdi.tck.cdi.Sections.DECORATOR_BEAN;
 import static org.jboss.cdi.tck.cdi.Sections.DECORATOR_RESOLUTION;
 import static org.jboss.cdi.tck.cdi.Sections.DELEGATE_ATTRIBUTE;
 import static org.jboss.cdi.tck.cdi.Sections.ENABLED_DECORATORS_BEAN_ARCHIVE;
-import static org.jboss.cdi.tck.util.Assert.assertAnnotationSetMatches;
+import static org.jboss.cdi.tck.util.Assert.assertAnnotationsMatch;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -114,7 +114,7 @@ public class DecoratorDefinitionTest extends AbstractTest {
         assertTrue(decorator.getInjectionPoints().iterator().next().getAnnotated().isAnnotationPresent(Delegate.class));
         assertEquals(decorator.getDelegateType(), Logger.class);
         assertEquals(decorator.getDelegateQualifiers().size(), 1);
-        assertAnnotationSetMatches(decorator.getDelegateQualifiers(), Default.class);
+        assertAnnotationsMatch(decorator.getDelegateQualifiers(), Default.class);
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/AlternativeMetadataTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/AlternativeMetadataTest.java
@@ -15,6 +15,7 @@ package org.jboss.cdi.tck.tests.full.extensions.alternative.metadata;
 
 import static org.jboss.cdi.tck.TestGroups.CDI_FULL;
 import static org.jboss.cdi.tck.cdi.Sections.ALTERNATIVE_METADATA_SOURCES;
+import static org.jboss.cdi.tck.util.Assert.assertAnnotationsMatch;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -228,7 +229,7 @@ public class AlternativeMetadataTest extends AbstractTest {
         Set<Annotation> qualifiers = getContextualReference(Grocery.class, Any.Literal.INSTANCE).getFruit().getMetadata()
                 .getQualifiers();
         assertEquals(qualifiers.size(), 1);
-        assertTrue(annotationSetMatches(qualifiers, Cheap.class));
+        assertAnnotationsMatch(qualifiers, Cheap.class);
     }
 
     @Test
@@ -254,7 +255,7 @@ public class AlternativeMetadataTest extends AbstractTest {
         Set<Annotation> qualifiers = getContextualReference(Grocery.class, Any.Literal.INSTANCE).getInitializerFruit()
                 .getMetadata()
                 .getQualifiers();
-        assertTrue(annotationSetMatches(qualifiers, Cheap.class));
+        assertAnnotationsMatch(qualifiers, Cheap.class);
     }
 
     @Test
@@ -280,7 +281,7 @@ public class AlternativeMetadataTest extends AbstractTest {
         Set<Annotation> qualifiers = getContextualReference(Yogurt.class, Any.Literal.INSTANCE).getFruit().getMetadata()
                 .getQualifiers();
         assertEquals(qualifiers.size(), 1);
-        assertTrue(annotationSetMatches(qualifiers, Cheap.class));
+        assertAnnotationsMatch(qualifiers, Cheap.class);
     }
 
     @Test
@@ -304,7 +305,7 @@ public class AlternativeMetadataTest extends AbstractTest {
         assertNotNull(event);
         assertNotNull(parameter);
         assertEquals(parameter.getMetadata().getQualifiers().size(), 1);
-        assertTrue(annotationSetMatches(parameter.getMetadata().getQualifiers(), Cheap.class));
+        assertAnnotationsMatch(parameter.getMetadata().getQualifiers(), Cheap.class);
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/annotated/AnnotatedTypeAnnotationsTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/annotated/AnnotatedTypeAnnotationsTest.java
@@ -16,7 +16,7 @@ package org.jboss.cdi.tck.tests.full.extensions.alternative.metadata.annotated;
 
 import static org.jboss.cdi.tck.TestGroups.CDI_FULL;
 import static org.jboss.cdi.tck.cdi.Sections.ALTERNATIVE_METADATA_SOURCES;
-import static org.jboss.cdi.tck.util.Assert.assertAnnotationSetMatches;
+import static org.jboss.cdi.tck.util.Assert.assertAnnotationsMatch;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
@@ -60,9 +60,9 @@ public class AnnotatedTypeAnnotationsTest extends AbstractTest {
     @Test
     @SpecAssertions({ @SpecAssertion(section = ALTERNATIVE_METADATA_SOURCES, id = "b") })
     public void testCreateAnnotatedType() {
-        assertAnnotationSetMatches(getCurrentManager().createAnnotatedType(Android.class).getAnnotations(),
+        assertAnnotationsMatch(getCurrentManager().createAnnotatedType(Android.class).getAnnotations(),
                 RequestScoped.class, InheritedQualifier.class, Fate.class);
-        assertAnnotationSetMatches(getCurrentManager().createAnnotatedType(Rimmer.class).getAnnotations(), Mortal.class,
+        assertAnnotationsMatch(getCurrentManager().createAnnotatedType(Rimmer.class).getAnnotations(), Mortal.class,
                 Dependent.class, InheritedQualifier.class, Fate.class);
     }
 
@@ -73,11 +73,11 @@ public class AnnotatedTypeAnnotationsTest extends AbstractTest {
 
         AnnotatedType<Kryten> kryten = extension.getKryten();
         assertNotNull(kryten);
-        assertAnnotationSetMatches(kryten.getAnnotations(), RequestScoped.class, InheritedQualifier.class, Fate.class);
+        assertAnnotationsMatch(kryten.getAnnotations(), RequestScoped.class, InheritedQualifier.class, Fate.class);
 
         AnnotatedType<Rimmer> rimmer = extension.getRimmer();
         assertNotNull(rimmer);
-        assertAnnotationSetMatches(rimmer.getAnnotations(), Mortal.class, Dependent.class, InheritedQualifier.class,
+        assertAnnotationsMatch(rimmer.getAnnotations(), Mortal.class, Dependent.class, InheritedQualifier.class,
                 Fate.class);
     }
 
@@ -88,7 +88,7 @@ public class AnnotatedTypeAnnotationsTest extends AbstractTest {
 
         AnnotatedType<Android> android = extension.getAndroid();
         assertNotNull(android);
-        assertAnnotationSetMatches(android.getAnnotations(), RequestScoped.class, InheritedQualifier.class, Fate.class);
+        assertAnnotationsMatch(android.getAnnotations(), RequestScoped.class, InheritedQualifier.class, Fate.class);
     }
 
     @SuppressWarnings("unchecked")
@@ -99,13 +99,13 @@ public class AnnotatedTypeAnnotationsTest extends AbstractTest {
         List<AnnotatedType<Human>> humans = extension.getAllHumans();
         assertNotNull(humans);
         assertEquals(humans.size(), 1);
-        assertAnnotationSetMatches(humans.iterator().next().getAnnotations(), Mortal.class, Dependent.class,
+        assertAnnotationsMatch(humans.iterator().next().getAnnotations(), Mortal.class, Dependent.class,
                 InheritedQualifier.class, Fate.class);
 
         List<AnnotatedType<Android>> androids = extension.getAllAndroids();
         assertNotNull(androids);
         assertEquals(androids.size(), 1);
-        assertAnnotationSetMatches(androids.iterator().next().getAnnotations(), RequestScoped.class, InheritedQualifier.class,
+        assertAnnotationsMatch(androids.iterator().next().getAnnotations(), RequestScoped.class, InheritedQualifier.class,
                 Fate.class);
     }
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/AlternativeMetaDataTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/AlternativeMetaDataTest.java
@@ -16,7 +16,7 @@ package org.jboss.cdi.tck.tests.full.extensions.annotated;
 
 import static org.jboss.cdi.tck.TestGroups.CDI_FULL;
 import static org.jboss.cdi.tck.cdi.Sections.ALTERNATIVE_METADATA_SOURCES;
-import static org.jboss.cdi.tck.util.Assert.assertAnnotationSetMatches;
+import static org.jboss.cdi.tck.util.Assert.assertAnnotationsMatch;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -92,9 +92,9 @@ public class AlternativeMetaDataTest extends AbstractTest {
     public void testGetAnnotations() {
         AnnotatedType<?> annotatedType = getCurrentManager().createAnnotatedType(ClassD.class);
         assert annotatedType.getAnnotations().size() == 2;
-        assert annotationSetMatches(annotatedType.getAnnotations(), RequestScoped.class, Tame.class);
+        assertAnnotationsMatch(annotatedType.getAnnotations(), RequestScoped.class, Tame.class);
         AnnotatedType<WildCat> annotatedWildCatType = getCurrentManager().createAnnotatedType(WildCat.class);
-        assertAnnotationSetMatches(annotatedWildCatType.getAnnotations(), RequestScoped.class);
+        assertAnnotationsMatch(annotatedWildCatType.getAnnotations(), RequestScoped.class);
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/WithAnnotationsTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/WithAnnotationsTest.java
@@ -16,7 +16,7 @@ package org.jboss.cdi.tck.tests.full.extensions.annotated.delivery;
 
 import static org.jboss.cdi.tck.TestGroups.CDI_FULL;
 import static org.jboss.cdi.tck.cdi.Sections.PROCESS_ANNOTATED_TYPE;
-import static org.jboss.cdi.tck.util.Assert.assertTypeListMatches;
+import static org.jboss.cdi.tck.util.Assert.assertTypesMatch;
 import static org.testng.Assert.assertFalse;
 
 import jakarta.inject.Inject;
@@ -67,7 +67,7 @@ public class WithAnnotationsTest extends AbstractTest {
     public void testDelivery() {
 
         // Annotated with @Desired or @Wanted
-        assertTypeListMatches(processAnnotatedTypeObserver.getProcessedDesiredAndWantedTypes(),
+        assertTypesMatch(processAnnotatedTypeObserver.getProcessedDesiredAndWantedTypes(),
                 // type-level
                 Bird.class, Hummingbird.class, BeeHummingbird.class,
                 // member-level
@@ -75,7 +75,7 @@ public class WithAnnotationsTest extends AbstractTest {
                 OcellatedTurkey.class, Jack.class, Sparrow.class, AplomadoFalcon.class);
 
         // Annotated with @Desired only
-        assertTypeListMatches(processAnnotatedTypeObserver.getProcessedDesiredTypes(),
+        assertTypesMatch(processAnnotatedTypeObserver.getProcessedDesiredTypes(),
                 // type-level
                 Bird.class, Hummingbird.class, BeeHummingbird.class,
                 // member-level
@@ -89,7 +89,7 @@ public class WithAnnotationsTest extends AbstractTest {
             @SpecAssertion(section = PROCESS_ANNOTATED_TYPE, id = "fc"),
             @SpecAssertion(section = PROCESS_ANNOTATED_TYPE, id = "g") })
     public void testDeliveryMetaAnnotation() {
-        assertTypeListMatches(processAnnotatedTypeObserver.getProcessedMetaAnnotationTypes(), Chicken.class, Hen.class,
+        assertTypesMatch(processAnnotatedTypeObserver.getProcessedMetaAnnotationTypes(), Chicken.class, Hen.class,
                 RubberChicken.class, Hummingbird.class, BeeHummingbird.class);
     }
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/BeanManagerTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/BeanManagerTest.java
@@ -24,6 +24,7 @@ import static org.jboss.cdi.tck.cdi.Sections.BM_OBTAIN_ANNOTATEDTYPE;
 import static org.jboss.cdi.tck.cdi.Sections.BM_OBTAIN_EXTENSION;
 import static org.jboss.cdi.tck.cdi.Sections.BM_OBTAIN_INJECTIONTARGET;
 import static org.jboss.cdi.tck.cdi.Sections.BM_VALIDATE_IP;
+import static org.jboss.cdi.tck.util.Assert.assertAnnotationsMatch;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -122,7 +123,7 @@ public class BeanManagerTest extends AbstractTest {
     public void testGetMetaAnnotationsForInterceptorBindingType() {
         Set<Annotation> metaAnnotations = getCurrentManager().getInterceptorBindingDefinition(Transactional.class);
         assertEquals(metaAnnotations.size(), 4);
-        assert annotationSetMatches(metaAnnotations, Target.class, Retention.class, Documented.class, InterceptorBinding.class);
+        assertAnnotationsMatch(metaAnnotations, Target.class, Retention.class, Documented.class, InterceptorBinding.class);
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/beanAttributes/CreateBeanAttributesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/beanAttributes/CreateBeanAttributesTest.java
@@ -15,6 +15,8 @@ package org.jboss.cdi.tck.tests.full.extensions.beanManager.beanAttributes;
 
 import static org.jboss.cdi.tck.TestGroups.CDI_FULL;
 import static org.jboss.cdi.tck.cdi.Sections.BM_OBTAIN_BEANATTRIBUTES;
+import static org.jboss.cdi.tck.util.Assert.assertAnnotationsMatch;
+import static org.jboss.cdi.tck.util.Assert.assertTypesMatch;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
@@ -66,9 +68,9 @@ public class CreateBeanAttributesTest extends AbstractTest {
         AnnotatedType<Mountain> type = getCurrentManager().createAnnotatedType(Mountain.class);
         BeanAttributes<Mountain> attributes = getCurrentManager().createBeanAttributes(type);
 
-        assertTrue(typeSetMatches(attributes.getTypes(), Landmark.class, Object.class));
-        assertTrue(typeSetMatches(attributes.getStereotypes(), TundraStereotype.class));
-        assertTrue(annotationSetMatches(attributes.getQualifiers(), Natural.class, Any.class));
+        assertTypesMatch(attributes.getTypes(), Landmark.class, Object.class);
+        assertTypesMatch(attributes.getStereotypes(), TundraStereotype.class);
+        assertAnnotationsMatch(attributes.getQualifiers(), Natural.class, Any.class);
         assertEquals(attributes.getScope(), ApplicationScoped.class);
         assertEquals(attributes.getName(), "mountain");
         assertTrue(attributes.isAlternative());
@@ -82,9 +84,9 @@ public class CreateBeanAttributesTest extends AbstractTest {
         AnnotatedType<Mountain> wrappedType = new AnnotatedTypeWrapper<Mountain>(type, false, NamedLiteral.of("Mount Blanc"));
         BeanAttributes<Mountain> attributes = getCurrentManager().createBeanAttributes(wrappedType);
 
-        assertTrue(typeSetMatches(attributes.getTypes(), Mountain.class, Landmark.class, Object.class));
+        assertTypesMatch(attributes.getTypes(), Mountain.class, Landmark.class, Object.class);
         assertTrue(attributes.getStereotypes().isEmpty());
-        assertTrue(annotationSetMatches(attributes.getQualifiers(), Named.class, Any.class, Default.class));
+        assertAnnotationsMatch(attributes.getQualifiers(), Named.class, Any.class, Default.class);
         assertEquals(attributes.getScope(), Dependent.class);
         assertEquals(attributes.getName(), "Mount Blanc");
         assertFalse(attributes.isAlternative());
@@ -92,9 +94,9 @@ public class CreateBeanAttributesTest extends AbstractTest {
 
     @SuppressWarnings("unchecked")
     private void verifyLakeFish(BeanAttributes<?> attributes) {
-        assertTrue(typeSetMatches(attributes.getTypes(), Fish.class, Object.class));
-        assertTrue(typeSetMatches(attributes.getStereotypes(), TundraStereotype.class));
-        assertTrue(annotationSetMatches(attributes.getQualifiers(), Natural.class, Any.class, Named.class));
+        assertTypesMatch(attributes.getTypes(), Fish.class, Object.class);
+        assertTypesMatch(attributes.getStereotypes(), TundraStereotype.class);
+        assertAnnotationsMatch(attributes.getQualifiers(), Natural.class, Any.class, Named.class);
         assertEquals(attributes.getScope(), ApplicationScoped.class);
         assertEquals(attributes.getName(), "fish");
         assertTrue(attributes.isAlternative());
@@ -102,8 +104,8 @@ public class CreateBeanAttributesTest extends AbstractTest {
 
     @SuppressWarnings("unchecked")
     private void verifyDamFish(BeanAttributes<?> attributes) {
-        assertTrue(typeSetMatches(attributes.getTypes(), Fish.class, Animal.class, Object.class));
-        assertTrue(annotationSetMatches(attributes.getQualifiers(), Wild.class, Any.class));
+        assertTypesMatch(attributes.getTypes(), Fish.class, Animal.class, Object.class);
+        assertAnnotationsMatch(attributes.getQualifiers(), Wild.class, Any.class);
         assertTrue(attributes.getStereotypes().isEmpty());
         assertEquals(attributes.getScope(), Dependent.class);
         assertNull(attributes.getName());
@@ -112,8 +114,8 @@ public class CreateBeanAttributesTest extends AbstractTest {
 
     @SuppressWarnings("unchecked")
     private void verifyVolume(BeanAttributes<?> attributes) {
-        assertTrue(typeSetMatches(attributes.getTypes(), long.class, Object.class));
-        assertTrue(annotationSetMatches(attributes.getQualifiers(), Any.class, Default.class, Named.class));
+        assertTypesMatch(attributes.getTypes(), long.class, Object.class);
+        assertAnnotationsMatch(attributes.getQualifiers(), Any.class, Default.class, Named.class);
         assertTrue(attributes.getStereotypes().isEmpty());
         assertEquals(attributes.getScope(), Dependent.class);
         assertEquals(attributes.getName(), "volume");

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/injectionPoint/CreateInjectionPointTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/injectionPoint/CreateInjectionPointTest.java
@@ -15,6 +15,7 @@ package org.jboss.cdi.tck.tests.full.extensions.beanManager.injectionPoint;
 
 import static org.jboss.cdi.tck.TestGroups.CDI_FULL;
 import static org.jboss.cdi.tck.cdi.Sections.BM_OBTAIN_INJECTIONPOINT;
+import static org.jboss.cdi.tck.util.Assert.assertAnnotationsMatch;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -74,7 +75,7 @@ public class CreateInjectionPointTest extends AbstractTest {
         AnnotatedField<?> field = type.getFields().iterator().next();
         InjectionPoint ip = getCurrentManager().createInjectionPoint(field);
         validateParameterizedType(ip.getType(), Book.class, String.class);
-        annotationSetMatches(ip.getQualifiers(), Monograph.class, Fictional.class);
+        assertAnnotationsMatch(ip.getQualifiers(), Monograph.class, Fictional.class);
         assertNull(ip.getBean());
         assertEquals(field.getJavaMember(), ip.getMember());
         assertNotNull(ip.getAnnotated());
@@ -92,7 +93,7 @@ public class CreateInjectionPointTest extends AbstractTest {
         AnnotatedParameter<?> parameter = constructor.getParameters().get(1);
         InjectionPoint ip = getCurrentManager().createInjectionPoint(parameter);
         validateParameterizedType(ip.getType(), Book.class, String.class);
-        annotationSetMatches(ip.getQualifiers(), Fictional.class);
+        assertAnnotationsMatch(ip.getQualifiers(), Fictional.class);
         assertNull(ip.getBean());
         assertEquals(constructor.getJavaMember(), ip.getMember());
         assertNotNull(ip.getAnnotated());
@@ -105,12 +106,12 @@ public class CreateInjectionPointTest extends AbstractTest {
     @SpecAssertions({ @SpecAssertion(section = BM_OBTAIN_INJECTIONPOINT, id = "b") })
     public void testMethodParameter() {
         AnnotatedType<?> type = getCurrentManager().createAnnotatedType(Library.class);
-        assertEquals(1, type.getMethods().size());
+        assertEquals(type.getMethods().size(), 1);
         AnnotatedMethod<?> method = type.getMethods().iterator().next();
         AnnotatedParameter<?> parameter = method.getParameters().get(2);
         InjectionPoint ip = getCurrentManager().createInjectionPoint(parameter);
         validateParameterizedType(ip.getType(), Book.class, Integer.class);
-        annotationSetMatches(ip.getQualifiers(), Default.class);
+        assertAnnotationsMatch(ip.getQualifiers(), Default.class);
         assertNull(ip.getBean());
         assertEquals(method.getJavaMember(), ip.getMember());
         assertNotNull(ip.getAnnotated());

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/VerifyValuesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/VerifyValuesTest.java
@@ -16,6 +16,8 @@ package org.jboss.cdi.tck.tests.full.extensions.lifecycle.processBeanAttributes;
 import static org.jboss.cdi.tck.TestGroups.CDI_FULL;
 import static org.jboss.cdi.tck.cdi.Sections.BEAN_DISCOVERY_STEPS;
 import static org.jboss.cdi.tck.cdi.Sections.PROCESS_BEAN_ATTRIBUTES;
+import static org.jboss.cdi.tck.util.Assert.assertAnnotationsMatch;
+import static org.jboss.cdi.tck.util.Assert.assertTypesMatch;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -109,9 +111,9 @@ public class VerifyValuesTest extends AbstractTest {
         verifyName(attributes, "createBravo");
         assertTrue(attributes.isAlternative());
 
-        assertTrue(typeSetMatches(attributes.getTypes(), BravoInterface.class, Object.class));
-        assertTrue(typeSetMatches(attributes.getStereotypes(), AlphaStereotype.class));
-        assertTrue(annotationSetMatches(attributes.getQualifiers(), BravoQualifier.class, Named.class, Any.class));
+        assertTypesMatch(attributes.getTypes(), BravoInterface.class, Object.class);
+        assertTypesMatch(attributes.getStereotypes(), AlphaStereotype.class);
+        assertAnnotationsMatch(attributes.getQualifiers(), BravoQualifier.class, Named.class, Any.class);
     }
 
     @Test
@@ -132,13 +134,13 @@ public class VerifyValuesTest extends AbstractTest {
     public void testProducerFieldBeanAttributes() {
         BeanAttributes<Charlie> attributes = extension.getProducedCharlieAttributes();
         assertNotNull(attributes);
-        assertEquals(ApplicationScoped.class, attributes.getScope());
+        assertEquals(attributes.getScope(), ApplicationScoped.class);
         verifyName(attributes, "charlie");
         assertFalse(attributes.isAlternative());
 
-        assertTrue(typeSetMatches(attributes.getTypes(), Object.class, Charlie.class, CharlieInterface.class));
-        assertTrue(typeSetMatches(attributes.getStereotypes(), AlphaStereotype.class));
-        assertTrue(annotationSetMatches(attributes.getQualifiers(), CharlieQualifier.class, Named.class, Any.class));
+        assertTypesMatch(attributes.getTypes(), Object.class, Charlie.class, CharlieInterface.class);
+        assertTypesMatch(attributes.getStereotypes(), AlphaStereotype.class);
+        assertAnnotationsMatch(attributes.getQualifiers(), CharlieQualifier.class, Named.class, Any.class);
     }
 
     @Test
@@ -147,10 +149,10 @@ public class VerifyValuesTest extends AbstractTest {
     public void testInterceptorBeanAttributes() {
         BeanAttributes<BravoInterceptor> attributes = extension.getBravoInterceptorAttributes();
         assertNotNull(attributes);
-        assertEquals(Dependent.class, attributes.getScope());
+        assertEquals(attributes.getScope(), Dependent.class);
         assertFalse(attributes.isAlternative());
 
-        assertTrue(typeSetMatches(attributes.getTypes(), Object.class, BravoInterceptor.class));
+        assertTypesMatch(attributes.getTypes(), Object.class, BravoInterceptor.class);
         assertTrue(attributes.getStereotypes().isEmpty());
     }
 
@@ -160,12 +162,12 @@ public class VerifyValuesTest extends AbstractTest {
     public void testDecoratorBeanAttributes() {
         BeanAttributes<BravoDecorator> attributes = extension.getBravoDecoratorAttributes();
         assertNotNull(attributes);
-        assertEquals(Dependent.class, attributes.getScope());
+        assertEquals(attributes.getScope(), Dependent.class);
         assertFalse(attributes.isAlternative());
 
-        assertTrue(typeSetMatches(attributes.getTypes(), Object.class, BravoDecorator.class, BravoInterface.class));
-        assertTrue(attributes.getStereotypes().size() == 1);
-        assertTrue(attributes.getStereotypes().iterator().next().equals(Decorator.class));
+        assertTypesMatch(attributes.getTypes(), Object.class, BravoDecorator.class, BravoInterface.class);
+        assertEquals(attributes.getStereotypes().size(), 1);
+        assertEquals(attributes.getStereotypes().iterator().next(), Decorator.class);
     }
 
     private void verifyName(BeanAttributes<?> attributes, String name) {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/modify/SetBeanAttributesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/modify/SetBeanAttributesTest.java
@@ -15,7 +15,8 @@ package org.jboss.cdi.tck.tests.full.extensions.lifecycle.processBeanAttributes.
 
 import static org.jboss.cdi.tck.TestGroups.CDI_FULL;
 import static org.jboss.cdi.tck.cdi.Sections.PROCESS_BEAN_ATTRIBUTES;
-import static org.jboss.cdi.tck.util.Assert.assertTypeSetMatches;
+import static org.jboss.cdi.tck.util.Assert.assertAnnotationsMatch;
+import static org.jboss.cdi.tck.util.Assert.assertTypesMatch;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -74,14 +75,13 @@ public class SetBeanAttributesTest extends AbstractTest {
 
         Bean<Cat> bean = getUniqueBean(Cat.class, new Cute.Literal());
 
-        assertTypeSetMatches(bean.getTypes(), Object.class, Cat.class);
-        assertTypeSetMatches(bean.getStereotypes(), PersianStereotype.class);
-        assertTrue(
-                annotationSetMatches(bean.getQualifiers(), new Wild.Literal(true), new Cute.Literal(), Any.Literal.INSTANCE));
+        assertTypesMatch(bean.getTypes(), Object.class, Cat.class);
+        assertTypesMatch(bean.getStereotypes(), PersianStereotype.class);
+        assertAnnotationsMatch(bean.getQualifiers(), new Wild.Literal(true), new Cute.Literal(), Any.Literal.INSTANCE);
 
         // other attributes
-        assertEquals(ApplicationScoped.class, bean.getScope());
-        assertEquals(true, bean.isAlternative());
+        assertEquals(bean.getScope(), ApplicationScoped.class);
+        assertTrue(bean.isAlternative());
     }
 
     @Test
@@ -89,6 +89,6 @@ public class SetBeanAttributesTest extends AbstractTest {
     public void testChangesAreNotPropagated() {
         // No qualifiers, stereotypes, scope
         assertTrue(extension.getCatAnnotatedType().getAnnotations().isEmpty());
-        assertTypeSetMatches(extension.getCatAnnotatedType().getTypeClosure(), Object.class, Cat.class, Animal.class);
+        assertTypesMatch(extension.getCatAnnotatedType().getTypeClosure(), Object.class, Cat.class, Animal.class);
     }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/specialization/SpecializationTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/specialization/SpecializationTest.java
@@ -16,6 +16,7 @@ package org.jboss.cdi.tck.tests.full.extensions.lifecycle.processBeanAttributes.
 import static org.jboss.cdi.tck.TestGroups.CDI_FULL;
 import static org.jboss.cdi.tck.cdi.Sections.PROCESS_BEAN_ATTRIBUTES;
 import static org.jboss.cdi.tck.cdi.Sections.SPECIALIZATION;
+import static org.jboss.cdi.tck.util.Assert.assertAnnotationsMatch;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
@@ -68,7 +69,7 @@ public class SpecializationTest extends AbstractTest {
         assertNull(extension.getBravo());
         BeanAttributes<Charlie> charlieAttributes = extension.getCharlie();
         assertNotNull(charlieAttributes);
-        annotationSetMatches(charlieAttributes.getQualifiers(), Foo.Literal.INSTANCE, Bar.Literal.INSTANCE,
+        assertAnnotationsMatch(charlieAttributes.getQualifiers(), Foo.Literal.INSTANCE, Bar.Literal.INSTANCE,
                 Baz.Literal.INSTANCE, Any.Literal.INSTANCE, NamedLiteral.of("alpha"));
         assertEquals(charlieAttributes.getName(), "alpha");
     }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/synthetic/ProcessBeanAttributesNotFiredForSyntheticBeanTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/synthetic/ProcessBeanAttributesNotFiredForSyntheticBeanTest.java
@@ -17,6 +17,7 @@ import static org.jboss.cdi.tck.TestGroups.CDI_FULL;
 import static org.jboss.cdi.tck.cdi.Sections.BM_OBTAIN_BEANATTRIBUTES;
 import static org.jboss.cdi.tck.cdi.Sections.PROCESS_ANNOTATED_TYPE;
 import static org.jboss.cdi.tck.cdi.Sections.PROCESS_BEAN_ATTRIBUTES;
+import static org.jboss.cdi.tck.util.Assert.assertTypesMatch;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
@@ -73,7 +74,7 @@ public class ProcessBeanAttributesNotFiredForSyntheticBeanTest extends AbstractT
 
         BeanAttributes<Bicycle> attributesBeforeRegistering = bicycleExtension.getBicycleAttributesBeforeRegistering();
         assertEquals(attributesBeforeRegistering.getScope(), ApplicationScoped.class);
-        assertTrue(typeSetMatches(attributesBeforeRegistering.getTypes(), Object.class, Vehicle.class, Bicycle.class));
+        assertTypesMatch(attributesBeforeRegistering.getTypes(), Object.class, Vehicle.class, Bicycle.class);
         assertFalse(attributesBeforeRegistering.isAlternative());
 
         assertNull(bicycleExtension.getBicycleAttributesBeforeModifying());
@@ -82,7 +83,7 @@ public class ProcessBeanAttributesNotFiredForSyntheticBeanTest extends AbstractT
         assertEquals(beans.size(), 1);
         Bean<Bicycle> bean = beans.iterator().next();
         assertEquals(bean.getScope(), ApplicationScoped.class);
-        assertTrue(typeSetMatches(bean.getTypes(), Object.class, Vehicle.class, Bicycle.class));
+        assertTypesMatch(bean.getTypes(), Object.class, Vehicle.class, Bicycle.class);
         assertFalse(bean.isAlternative());
     }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/ProcessInjectionPointFiredTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/ProcessInjectionPointFiredTest.java
@@ -16,6 +16,7 @@ package org.jboss.cdi.tck.tests.full.extensions.lifecycle.processInjectionPoint;
 import static org.jboss.cdi.tck.TestGroups.CDI_FULL;
 import static org.jboss.cdi.tck.cdi.Sections.BEAN_DISCOVERY_STEPS;
 import static org.jboss.cdi.tck.cdi.Sections.PROCESS_INJECTION_POINT;
+import static org.jboss.cdi.tck.util.Assert.assertAnnotationsMatch;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -73,7 +74,7 @@ public class ProcessInjectionPointFiredTest extends AbstractTest {
     public void testFieldInjectionPoint() {
         InjectionPoint ip = extension.getAlpha();
         assertNotNull(ip);
-        assertTrue(annotationSetMatches(ip.getQualifiers(), Foo.class));
+        assertAnnotationsMatch(ip.getQualifiers(), Foo.class);
         assertNotNull(ip.getBean());
         assertEquals(extension.getInjectingBean(), ip.getBean());
         verifyType(ip, Alpha.class, String.class);
@@ -92,7 +93,7 @@ public class ProcessInjectionPointFiredTest extends AbstractTest {
     public void testConstructorInjectionPoint() {
         InjectionPoint ip = extension.getBravo();
         assertNotNull(ip);
-        assertTrue(annotationSetMatches(ip.getQualifiers(), Bar.class));
+        assertAnnotationsMatch(ip.getQualifiers(), Bar.class);
         assertNotNull(ip.getBean());
         assertEquals(extension.getInjectingBean(), ip.getBean());
         verifyType(ip, Bravo.class, String.class);
@@ -110,7 +111,7 @@ public class ProcessInjectionPointFiredTest extends AbstractTest {
     public void testInitializerInjectionPoint() {
         InjectionPoint ip = extension.getCharlie();
         assertNotNull(ip);
-        assertTrue(annotationSetMatches(ip.getQualifiers(), Default.class));
+        assertAnnotationsMatch(ip.getQualifiers(), Default.class);
         assertNotNull(ip.getBean());
         assertEquals(extension.getInjectingBean(), ip.getBean());
         verifyType(ip, Charlie.class);
@@ -127,7 +128,7 @@ public class ProcessInjectionPointFiredTest extends AbstractTest {
     public void testProducerMethodInjectionPoint1() {
         InjectionPoint ip = extension.getProducerAlpha();
         assertNotNull(ip);
-        assertTrue(annotationSetMatches(ip.getQualifiers(), Foo.class));
+        assertAnnotationsMatch(ip.getQualifiers(), Foo.class);
         assertNotNull(ip.getBean());
         assertEquals(extension.getProducingBean(), ip.getBean());
         verifyType(ip, Alpha.class, Integer.class);
@@ -144,7 +145,7 @@ public class ProcessInjectionPointFiredTest extends AbstractTest {
     public void testProducerMethodInjectionPoint2() {
         InjectionPoint ip = extension.getProducerBravo();
         assertNotNull(ip);
-        assertTrue(annotationSetMatches(ip.getQualifiers(), Bar.class));
+        assertAnnotationsMatch(ip.getQualifiers(), Bar.class);
         assertNotNull(ip.getBean());
         assertEquals(extension.getProducingBean(), ip.getBean());
         verifyType(ip, Bravo.class, Integer.class);

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/processBean/ProcessBeanTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/processBean/ProcessBeanTest.java
@@ -16,6 +16,7 @@ package org.jboss.cdi.tck.tests.full.extensions.processBean;
 import static org.jboss.cdi.tck.TestGroups.CDI_FULL;
 import static org.jboss.cdi.tck.cdi.Sections.BEAN_DISCOVERY_STEPS;
 import static org.jboss.cdi.tck.cdi.Sections.PROCESS_BEAN;
+import static org.jboss.cdi.tck.util.Assert.assertAnnotationsMatch;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
@@ -75,7 +76,7 @@ public class ProcessBeanTest extends AbstractTest {
 
         assertNotNull(ProcessBeanObserver.getCatBean());
         assertEquals(ProcessBeanObserver.getCatBean().getBeanClass(), Cat.class);
-        assertTrue(annotationSetMatches(ProcessBeanObserver.getCatBean().getQualifiers(), Domestic.class, Any.class));
+        assertAnnotationsMatch(ProcessBeanObserver.getCatBean().getQualifiers(), Domestic.class, Any.class);
         assertEquals(ProcessBeanObserver.getCatAnnotatedType().getBaseType(), Cat.class);
         assertEquals(ProcessBeanObserver.getCatProcessBeanCount(), 2);
         assertTrue(ProcessBeanObserver.getCatAnnotated() instanceof AnnotatedType<?>);

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/ProducerMethodSpecializationTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/ProducerMethodSpecializationTest.java
@@ -17,6 +17,8 @@ import static org.jboss.cdi.tck.TestGroups.CDI_FULL;
 import static org.jboss.cdi.tck.cdi.Sections.DIRECT_AND_INDIRECT_SPECIALIZATION;
 import static org.jboss.cdi.tck.cdi.Sections.PRODUCER_OR_DISPOSER_METHODS_INVOCATION;
 import static org.jboss.cdi.tck.cdi.Sections.SPECIALIZE_PRODUCER_METHOD;
+import static org.jboss.cdi.tck.util.Assert.assertAnnotationsMatch;
+import static org.jboss.cdi.tck.util.Assert.assertTypesMatch;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -69,12 +71,12 @@ public class ProducerMethodSpecializationTest extends AbstractTest {
         // Check types of specializing bean
         Set<Type> expensiveNecklaceBeanTypes = expensiveNecklaceBean.getTypes();
         assertEquals(expensiveNecklaceBeanTypes.size(), 3);
-        assertTrue(typeSetMatches(expensiveNecklaceBeanTypes, Object.class, Product.class, Necklace.class));
+        assertTypesMatch(expensiveNecklaceBeanTypes, Object.class, Product.class, Necklace.class);
 
         // Check qualifiers of specializing bean
         Set<Annotation> expensiveNecklaceQualifiers = expensiveNecklaceBean.getQualifiers();
         assertEquals(expensiveNecklaceQualifiers.size(), 4);
-        assertTrue(annotationSetMatches(expensiveNecklaceQualifiers, Expensive.class, Sparkly.class, Any.class, Named.class));
+        assertAnnotationsMatch(expensiveNecklaceQualifiers, Expensive.class, Sparkly.class, Any.class, Named.class);
 
         // There is only one bean for type Necklace and qualifier Sparkly
         Set<Bean<Necklace>> sparklyNecklaceBeans = getBeans(Necklace.class, SPARKLY_LITERAL);

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/SimpleBeanSpecializationTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/SimpleBeanSpecializationTest.java
@@ -17,8 +17,9 @@ import static org.jboss.cdi.tck.TestGroups.CDI_FULL;
 import static org.jboss.cdi.tck.cdi.Sections.DIRECT_AND_INDIRECT_SPECIALIZATION;
 import static org.jboss.cdi.tck.cdi.Sections.SPECIALIZATION;
 import static org.jboss.cdi.tck.cdi.Sections.SPECIALIZE_MANAGED_BEAN;
+import static org.jboss.cdi.tck.util.Assert.assertAnnotationsMatch;
+import static org.jboss.cdi.tck.util.Assert.assertTypesMatch;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
@@ -69,7 +70,7 @@ public class SimpleBeanSpecializationTest extends AbstractTest {
         // Types of specializing bean
         Set<Type> lazyFarmerBeanTypes = lazyFarmerBean.getTypes();
         assertEquals(lazyFarmerBeanTypes.size(), 4);
-        assertTrue(typeSetMatches(lazyFarmerBeanTypes, Object.class, Human.class, Farmer.class, LazyFarmer.class));
+        assertTypesMatch(lazyFarmerBeanTypes, Object.class, Human.class, Farmer.class, LazyFarmer.class);
     }
 
     @Test(dataProvider = ARQUILLIAN_DATA_PROVIDER)
@@ -87,8 +88,8 @@ public class SimpleBeanSpecializationTest extends AbstractTest {
         Set<Annotation> lazyFarmerBeanQualifiers = lazyFarmerBean.getQualifiers();
         assertEquals(lazyFarmerBeanQualifiers.size(), 5);
         // LazyFarmer inherits Default from Human; LandOwner and Named from Farmer
-        assertTrue(annotationSetMatches(lazyFarmerBean.getQualifiers(), Landowner.class, Lazy.class, Any.class, Named.class,
-                Default.class));
+        assertAnnotationsMatch(lazyFarmerBean.getQualifiers(), Landowner.class, Lazy.class, Any.class, Named.class,
+                Default.class);
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/ProducerFieldDefinitionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/ProducerFieldDefinitionTest.java
@@ -26,9 +26,9 @@ import static org.jboss.cdi.tck.cdi.Sections.NAMED_STEREOTYPE;
 import static org.jboss.cdi.tck.cdi.Sections.PRODUCER_FIELD;
 import static org.jboss.cdi.tck.cdi.Sections.PRODUCER_FIELD_NAME;
 import static org.jboss.cdi.tck.cdi.Sections.PRODUCER_FIELD_TYPES;
+import static org.jboss.cdi.tck.util.Assert.assertAnnotationsMatch;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertTrue;
 
 import java.lang.annotation.Annotation;
 import java.util.List;
@@ -180,7 +180,7 @@ public class ProducerFieldDefinitionTest extends AbstractTest {
         Bean<Tarantula> staticTarantulaBean = getUniqueBean(Tarantula.class, STATIC_LITERAL);
         assertEquals(staticTarantulaBean.getName(), "produceTarantula");
         // Any, Static
-        assertTrue(annotationSetMatches(staticTarantulaBean.getQualifiers(), Any.Literal.INSTANCE, STATIC_LITERAL));
+        assertAnnotationsMatch(staticTarantulaBean.getQualifiers(), Any.Literal.INSTANCE, STATIC_LITERAL);
 
     }
 
@@ -190,8 +190,8 @@ public class ProducerFieldDefinitionTest extends AbstractTest {
         Bean<Tarantula> tarantulaBean = getUniqueBean(Tarantula.class, PET_LITERAL);
         assertEquals(tarantulaBean.getName(), "producedPetTarantula");
         // Any, Pet, Named
-        assertTrue(annotationSetMatches(tarantulaBean.getQualifiers(), Any.Literal.INSTANCE, PET_LITERAL, NamedLiteral.of(
-                "producedPetTarantula")));
+        assertAnnotationsMatch(tarantulaBean.getQualifiers(), Any.Literal.INSTANCE, PET_LITERAL,
+                NamedLiteral.of("producedPetTarantula"));
     }
 
     // review 2.2

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/ProducerMethodDefinitionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/ProducerMethodDefinitionTest.java
@@ -28,6 +28,8 @@ import static org.jboss.cdi.tck.cdi.Sections.METHOD_CONSTRUCTOR_PARAMETER_QUALIF
 import static org.jboss.cdi.tck.cdi.Sections.PRODUCER_METHOD;
 import static org.jboss.cdi.tck.cdi.Sections.PRODUCER_METHOD_TYPES;
 import static org.jboss.cdi.tck.cdi.Sections.PRODUCER_OR_DISPOSER_METHODS_INVOCATION;
+import static org.jboss.cdi.tck.util.Assert.assertAnnotationsMatch;
+import static org.jboss.cdi.tck.util.Assert.assertTypesMatch;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
@@ -48,7 +50,6 @@ import jakarta.enterprise.util.TypeLiteral;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
-import org.jboss.cdi.tck.util.Assert;
 import org.jboss.cdi.tck.util.DependentInstance;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.test.audit.annotations.SpecAssertion;
@@ -166,7 +167,7 @@ public class ProducerMethodDefinitionTest extends AbstractTest {
         Set<Bean<Integer>> beans = getBeans(Integer.class, NUMBER_LITERAL);
         assertEquals(beans.size(), 1);
         Bean<Integer> bean = beans.iterator().next();
-        Assert.assertTypeSetMatches(bean.getTypes(), Object.class, int.class);
+        assertTypesMatch(bean.getTypes(), Object.class, int.class);
     }
 
     @Test
@@ -218,8 +219,8 @@ public class ProducerMethodDefinitionTest extends AbstractTest {
         Bean<DaddyLongLegs> daddyLongLegs = getUniqueBean(DaddyLongLegs.class, TAME_LITERAL);
         assertEquals(daddyLongLegs.getName(), name);
         // Any, Tame, Named
-        assertTrue(annotationSetMatches(daddyLongLegs.getQualifiers(), Any.Literal.INSTANCE, TAME_LITERAL,
-                NamedLiteral.of(name)));
+        assertAnnotationsMatch(daddyLongLegs.getQualifiers(), Any.Literal.INSTANCE, TAME_LITERAL,
+                NamedLiteral.of(name));
     }
 
     // Review 2.2

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/name/ProducerMethodWithDefaultNameTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/name/ProducerMethodWithDefaultNameTest.java
@@ -16,11 +16,10 @@ package org.jboss.cdi.tck.tests.implementation.producer.method.definition.name;
 
 import static org.jboss.cdi.tck.cdi.Sections.NAMED_STEREOTYPE;
 import static org.jboss.cdi.tck.cdi.Sections.PRODUCER_METHOD_NAME;
+import static org.jboss.cdi.tck.util.Assert.assertAnnotationsMatch;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
 
 import jakarta.enterprise.inject.Any;
-import jakarta.enterprise.inject.Default;
 import jakarta.enterprise.inject.spi.Bean;
 
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -35,7 +34,6 @@ import org.testng.annotations.Test;
 /**
  * @author Martin Kouba
  */
-@SuppressWarnings("serial")
 @SpecVersion(spec = "cdi", version = "2.0")
 public class ProducerMethodWithDefaultNameTest extends AbstractTest {
 
@@ -67,7 +65,7 @@ public class ProducerMethodWithDefaultNameTest extends AbstractTest {
         String name = "produceJohn";
         Bean<Bug> john = getUniqueBean(Bug.class, new Funny.Literal());
         assertEquals(john.getName(), name);
-        assertTrue(annotationSetMatches(john.getQualifiers(), Any.Literal.INSTANCE, Default.Literal.INSTANCE));
+        assertAnnotationsMatch(john.getQualifiers(), Any.Literal.INSTANCE, new Funny.Literal());
     }
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/InjectionPointTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/InjectionPointTest.java
@@ -15,6 +15,7 @@ package org.jboss.cdi.tck.tests.lookup.injectionpoint;
 
 import static org.jboss.cdi.tck.cdi.Sections.CONTEXTUAL_REFERENCE;
 import static org.jboss.cdi.tck.cdi.Sections.INJECTION_POINT;
+import static org.jboss.cdi.tck.util.Assert.assertAnnotationsMatch;
 import static org.testng.Assert.assertTrue;
 
 import java.lang.annotation.Annotation;
@@ -162,7 +163,7 @@ public class InjectionPointTest extends AbstractTest {
         BeanWithInjectionPointMetadata beanWithInjectionPoint = beanWithInjectedBean.getInjectedBean();
         assert beanWithInjectionPoint.getInjectedMetadata() != null;
         assert beanWithInjectionPoint.getInjectedMetadata().getAnnotated() instanceof AnnotatedParameter<?>;
-        assert annotationSetMatches(beanWithInjectionPoint.getInjectedMetadata().getQualifiers(), Default.class);
+        assertAnnotationsMatch(beanWithInjectionPoint.getInjectedMetadata().getQualifiers(), Default.class);
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/dynamic/DynamicInjectionPointTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/dynamic/DynamicInjectionPointTest.java
@@ -15,6 +15,7 @@
 package org.jboss.cdi.tck.tests.lookup.injectionpoint.dynamic;
 
 import static org.jboss.cdi.tck.cdi.Sections.INJECTION_POINT;
+import static org.jboss.cdi.tck.util.Assert.assertAnnotationsMatch;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -79,8 +80,8 @@ public class DynamicInjectionPointTest extends AbstractTest {
         Set<Annotation> fooQualifiers = bar.getFoo().getInjectionPoint().getQualifiers();
         Set<Annotation> niceFooQualifiers = bar.getQualifierNiceFoo().getInjectionPoint().getQualifiers();
 
-        annotationSetMatches(fooQualifiers, Any.Literal.INSTANCE, Default.Literal.INSTANCE);
-        annotationSetMatches(niceFooQualifiers, Any.Literal.INSTANCE, new Nice.Literal());
+        assertAnnotationsMatch(fooQualifiers, Any.Literal.INSTANCE, Default.Literal.INSTANCE);
+        assertAnnotationsMatch(niceFooQualifiers, Any.Literal.INSTANCE, new Nice.Literal());
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/ResolutionByTypeTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/ResolutionByTypeTest.java
@@ -21,6 +21,7 @@ import static org.jboss.cdi.tck.cdi.Sections.PERFORMING_TYPESAFE_RESOLUTION;
 import static org.jboss.cdi.tck.cdi.Sections.PRIMITIVE_TYPES_AND_NULL_VALUES;
 import static org.jboss.cdi.tck.cdi.Sections.QUALIFIER_ANNOTATION_MEMBERS;
 import static org.jboss.cdi.tck.cdi.Sections.RESTRICTING_BEAN_TYPES;
+import static org.jboss.cdi.tck.util.Assert.assertTypesMatch;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -161,7 +162,7 @@ public class ResolutionByTypeTest extends AbstractTest {
         assertEquals(getBeans(Canary.class).size(), 1);
         Bean<Canary> bean = getUniqueBean(Canary.class);
         assertTrue(getBeans(Bird.class).isEmpty());
-        assertTrue(typeSetMatches(bean.getTypes(), Canary.class, Object.class));
+        assertTypesMatch(bean.getTypes(), Canary.class, Object.class);
     }
 
     @Test
@@ -171,7 +172,7 @@ public class ResolutionByTypeTest extends AbstractTest {
         assertTrue(getBeans(Emu.class).isEmpty());
         assertTrue(getBeans(EUROPEAN_FLIGHTLESS_BIRD).isEmpty());
         Bean<FlightlessBird<Australian>> bean = getUniqueBean(AUSTRALIAN_FLIGHTLESS_BIRD);
-        assertTrue(typeSetMatches(bean.getTypes(), AUSTRALIAN_FLIGHTLESS_BIRD.getType(), Object.class));
+        assertTypesMatch(bean.getTypes(), AUSTRALIAN_FLIGHTLESS_BIRD.getType(), Object.class);
     }
 
     @Test
@@ -180,7 +181,7 @@ public class ResolutionByTypeTest extends AbstractTest {
         assertEquals(getBeans(Parrot.class).size(), 1);
         assertTrue(getBeans(Bird.class).isEmpty());
         Bean<Parrot> bean = getUniqueBean(Parrot.class);
-        assertTrue(typeSetMatches(bean.getTypes(), Parrot.class, Object.class));
+        assertTypesMatch(bean.getTypes(), Parrot.class, Object.class);
     }
 
     @Test
@@ -189,7 +190,7 @@ public class ResolutionByTypeTest extends AbstractTest {
         assertEquals(getBeans(EUROPEAN_CAT, TAME).size(), 1);
         assertTrue(getBeans(DomesticCat.class, TAME).isEmpty());
         Bean<Cat<European>> bean = getUniqueBean(EUROPEAN_CAT, TAME);
-        assertTrue(typeSetMatches(bean.getTypes(), EUROPEAN_CAT.getType(), Object.class));
+        assertTypesMatch(bean.getTypes(), EUROPEAN_CAT.getType(), Object.class);
     }
 
     @Test
@@ -198,7 +199,7 @@ public class ResolutionByTypeTest extends AbstractTest {
         assertEquals(getBeans(AFRICAN_CAT, WILD).size(), 1);
         assertTrue(getBeans(Lion.class, WILD).isEmpty());
         Bean<Cat<African>> bean = getUniqueBean(AFRICAN_CAT, WILD);
-        assertTrue(typeSetMatches(bean.getTypes(), AFRICAN_CAT.getType(), Object.class));
+        assertTypesMatch(bean.getTypes(), AFRICAN_CAT.getType(), Object.class);
     }
 
     @Test
@@ -207,6 +208,6 @@ public class ResolutionByTypeTest extends AbstractTest {
         assertEquals(getBeans(Dove.class).size(), 1);
         assertTrue(getBeans(Bird.class).isEmpty());
         Bean<Dove> bean = getUniqueBean(Dove.class);
-        assertTrue(typeSetMatches(bean.getTypes(), Dove.class, Object.class));
+        assertTypesMatch(bean.getTypes(), Dove.class, Object.class);
     }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/AssignabilityOfRawAndParameterizedTypesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/AssignabilityOfRawAndParameterizedTypesTest.java
@@ -18,9 +18,14 @@ import static org.jboss.cdi.tck.cdi.Sections.LEGAL_BEAN_TYPES;
 import static org.jboss.cdi.tck.cdi.Sections.LEGAL_INJECTION_POINT_TYPES;
 import static org.jboss.cdi.tck.cdi.Sections.PERFORMING_TYPESAFE_RESOLUTION;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -96,7 +101,7 @@ public class AssignabilityOfRawAndParameterizedTypesTest extends AbstractTest {
                 new TypeLiteral<Result<? extends Throwable, ? super Exception>>() {
                 });
         assert beans.size() == 1;
-        assert rawTypeSetMatches(beans.iterator().next().getTypes(), RESULT_TYPES);
+        assertRawTypeSetMatches(beans.iterator().next().getTypes(), RESULT_TYPES);
     }
 
     @Test
@@ -107,7 +112,7 @@ public class AssignabilityOfRawAndParameterizedTypesTest extends AbstractTest {
                 new TypeLiteral<Result<? extends RuntimeException, ? super RuntimeException>>() {
                 });
         assert beans.size() == 1;
-        assert rawTypeSetMatches(beans.iterator().next().getTypes(), RESULT_TYPES);
+        assertRawTypeSetMatches(beans.iterator().next().getTypes(), RESULT_TYPES);
     }
 
     @Test
@@ -121,12 +126,12 @@ public class AssignabilityOfRawAndParameterizedTypesTest extends AbstractTest {
         Set<Bean<Box<? super T1>>> beans1 = getBeans(new TypeLiteral<Box<? super T1>>() {
         });
         assertEquals(beans1.size(), 1);
-        assertTrue(rawTypeSetMatches(beans1.iterator().next().getTypes(), BOX_TYPES));
+        assertRawTypeSetMatches(beans1.iterator().next().getTypes(), BOX_TYPES);
 
         Set<Bean<Box<? super T2>>> beans2 = getBeans(new TypeLiteral<Box<? super T2>>() {
         });
         assertEquals(beans2.size(), 1);
-        assertTrue(rawTypeSetMatches(beans2.iterator().next().getTypes(), BOX_TYPES));
+        assertRawTypeSetMatches(beans2.iterator().next().getTypes(), BOX_TYPES);
 
         // SuperFoo does not extend Foo
         Set<Bean<Box<? super T3>>> noBeans3 = getBeans(new TypeLiteral<Box<? super T3>>() {
@@ -146,7 +151,7 @@ public class AssignabilityOfRawAndParameterizedTypesTest extends AbstractTest {
         Set<Bean<Box<? super T6>>> beans6 = getBeans(new TypeLiteral<Box<? super T6>>() {
         });
         assertEquals(beans6.size(), 1);
-        assertTrue(rawTypeSetMatches(beans6.iterator().next().getTypes(), BOX_TYPES));
+        assertRawTypeSetMatches(beans6.iterator().next().getTypes(), BOX_TYPES);
     }
 
     @Test
@@ -156,7 +161,7 @@ public class AssignabilityOfRawAndParameterizedTypesTest extends AbstractTest {
                 new TypeLiteral<Result<RuntimeException, IllegalStateException>>() {
                 });
         assert beans.size() == 1;
-        assert rawTypeSetMatches(beans.iterator().next().getTypes(), RESULT_TYPES);
+        assertRawTypeSetMatches(beans.iterator().next().getTypes(), RESULT_TYPES);
 
         Set<Bean<Result<RuntimeException, Throwable>>> noBeans = getBeans(
                 new TypeLiteral<Result<RuntimeException, Throwable>>() {
@@ -170,7 +175,7 @@ public class AssignabilityOfRawAndParameterizedTypesTest extends AbstractTest {
         Set<Bean<Box<BarSubBazFooImpl>>> beans = getBeans(new TypeLiteral<Box<BarSubBazFooImpl>>() {
         });
         assertEquals(beans.size(), 1);
-        assertTrue(rawTypeSetMatches(beans.iterator().next().getTypes(), BOX_TYPES));
+        assertRawTypeSetMatches(beans.iterator().next().getTypes(), BOX_TYPES);
 
         // SuperFoo is not inside BoxBarBazFooImpl's bounds
         Set<Bean<Box<BarBazSuperFooImpl>>> noBeans1 = getBeans(new TypeLiteral<Box<BarBazSuperFooImpl>>() {
@@ -189,7 +194,7 @@ public class AssignabilityOfRawAndParameterizedTypesTest extends AbstractTest {
         Set<Bean<Result<T1, T2>>> beans = getBeans(new TypeLiteral<Result<T1, T2>>() {
         });
         assert beans.size() == 1;
-        assert rawTypeSetMatches(beans.iterator().next().getTypes(), RESULT_TYPES);
+        assertRawTypeSetMatches(beans.iterator().next().getTypes(), RESULT_TYPES);
 
         Set<Bean<Result<T1, T3>>> noBeans = getBeans(new TypeLiteral<Result<T1, T3>>() {
         });
@@ -198,7 +203,7 @@ public class AssignabilityOfRawAndParameterizedTypesTest extends AbstractTest {
         Set<Bean<Dao<T1, T3>>> daoBeans = getBeans(new TypeLiteral<Dao<T1, T3>>() {
         });
         assertEquals(daoBeans.size(), 1);
-        assertTrue(rawTypeSetMatches(daoBeans.iterator().next().getTypes(), DAO_TYPES));
+        assertRawTypeSetMatches(daoBeans.iterator().next().getTypes(), DAO_TYPES);
     }
 
     @Test
@@ -207,12 +212,12 @@ public class AssignabilityOfRawAndParameterizedTypesTest extends AbstractTest {
         Set<Bean<Box<T1>>> beans1 = getBeans(new TypeLiteral<Box<T1>>() {
         });
         assertEquals(beans1.size(), 1);
-        assertTrue(rawTypeSetMatches(beans1.iterator().next().getTypes(), BOX_TYPES));
+        assertRawTypeSetMatches(beans1.iterator().next().getTypes(), BOX_TYPES);
 
         Set<Bean<Box<T2>>> beans2 = getBeans(new TypeLiteral<Box<T2>>() {
         });
         assertEquals(beans2.size(), 1);
-        assertTrue(rawTypeSetMatches(beans2.iterator().next().getTypes(), BOX_TYPES));
+        assertRawTypeSetMatches(beans2.iterator().next().getTypes(), BOX_TYPES);
 
         // SuperFoo does not extend Foo
         Set<Bean<Box<T3>>> noBeans3 = getBeans(new TypeLiteral<Box<T3>>() {
@@ -232,6 +237,30 @@ public class AssignabilityOfRawAndParameterizedTypesTest extends AbstractTest {
         Set<Bean<Box<T6>>> beans6 = getBeans(new TypeLiteral<Box<T6>>() {
         });
         assertEquals(beans6.size(), 1);
-        assertTrue(rawTypeSetMatches(beans6.iterator().next().getTypes(), BOX_TYPES));
+        assertRawTypeSetMatches(beans6.iterator().next().getTypes(), BOX_TYPES);
+    }
+
+    /**
+     * Checks if the erasure of the given set of {@code types} contains all given {@code requiredTypes} and no other.
+     *
+     * @param types the set of types whose erasures should be checked
+     * @param requiredTypes the set of types to match
+     */
+    private void assertRawTypeSetMatches(Set<Type> types, Class<?>... requiredTypes) {
+        Set<Class<?>> rawTypes = new HashSet<>();
+        for (Type type : types) {
+            if (type instanceof Class<?> c) {
+                rawTypes.add(c);
+            } else if (type instanceof ParameterizedType pt) {
+                rawTypes.add((Class<?>) pt.getRawType());
+            }
+        }
+
+        List<Class<?>> requiredTypeList = Arrays.asList(requiredTypes);
+
+        if (requiredTypes.length != rawTypes.size() || !requiredTypeList.containsAll(rawTypes)) {
+            fail(String.format("Set %s (%s) does not match array %s (%s)", types, types.size(),
+                    requiredTypeList, requiredTypeList.size()));
+        }
     }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/util/Assert.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/util/Assert.java
@@ -14,19 +14,13 @@
 
 package org.jboss.cdi.tck.util;
 
-import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
-import java.util.Set;
-
-import jakarta.enterprise.inject.spi.Annotated;
-import jakarta.enterprise.inject.spi.AnnotatedMember;
-import jakarta.enterprise.inject.spi.AnnotatedParameter;
-import jakarta.enterprise.inject.spi.AnnotatedType;
 
 /**
  * @author Martin Kouba
@@ -38,12 +32,14 @@ public class Assert {
     }
 
     /**
+     * Asserts that given collection of {@code annotations} contains annotations of all given
+     * {@code requiredAnnotationTypes} and no other.
      *
-     * @param annotations
-     * @param requiredAnnotationTypes
-     * @throws AssertionError if the annotations set and required annotations do not match
+     * @param annotations the collection of annotations to check
+     * @param requiredAnnotationTypes the annotation types to match
      */
-    public static void assertAnnotationSetMatches(Set<? extends Annotation> annotations,
+    @SafeVarargs
+    public static void assertAnnotationsMatch(Collection<? extends Annotation> annotations,
             Class<? extends Annotation>... requiredAnnotationTypes) {
 
         if (annotations == null) {
@@ -51,11 +47,11 @@ public class Assert {
         }
 
         if (annotations.size() != requiredAnnotationTypes.length) {
-            fail(String.format("Set %s (%s) does not match array %s (%s)", annotations, annotations.size(),
+            fail(String.format("Collection %s (%s) does not match array %s (%s)", annotations, annotations.size(),
                     Arrays.toString(requiredAnnotationTypes), requiredAnnotationTypes.length));
         }
 
-        if (annotations.isEmpty() && requiredAnnotationTypes.length == 0) {
+        if (annotations.isEmpty()) {
             return;
         }
 
@@ -63,71 +59,48 @@ public class Assert {
 
         for (Annotation annotation : annotations) {
             if (!requiredAnnotationTypesList.contains(annotation.annotationType())) {
-                fail(String.format("Set %s (%s) does not match array %s (%s)", annotations, annotations.size(),
+                fail(String.format("Collection %s (%s) does not match array %s (%s)", annotations, annotations.size(),
                         requiredAnnotationTypesList, requiredAnnotationTypesList.size()));
             }
         }
     }
 
     /**
+     * Asserts that given collection of {@code annotations} contains all given {@code requiredAnnotations} and no other.
      *
-     * @param types
-     * @param requiredTypes
+     * @param annotations the collection of annotations to check
+     * @param requiredAnnotations the annotations to match
      */
-    public static void assertTypeSetMatches(Set<? extends Type> types, Type... requiredTypes) {
+    public static void assertAnnotationsMatch(Collection<? extends Annotation> annotations,
+            Annotation... requiredAnnotations) {
+        if (annotations == null) {
+            throw new IllegalArgumentException();
+        }
 
+        List<Annotation> requiredAnnotationList = Arrays.asList(requiredAnnotations);
+
+        if (requiredAnnotations.length != annotations.size() || !annotations.containsAll(requiredAnnotationList)) {
+            fail(String.format("Collection %s (%s) does not match array %s (%s)", annotations, annotations.size(),
+                    requiredAnnotationList, requiredAnnotationList.size()));
+        }
+    }
+
+    /**
+     * Asserts that given collection of {@code types} contains all given {@code requiredTypes} and no other.
+     *
+     * @param types the collection of types to check
+     * @param requiredTypes the types to match
+     */
+    public static void assertTypesMatch(Collection<? extends Type> types, Type... requiredTypes) {
         if (types == null) {
             throw new IllegalArgumentException();
         }
 
         List<Type> requiredTypeList = Arrays.asList(requiredTypes);
 
-        if (requiredTypes.length != types.size() || !types.containsAll(requiredTypeList)) {
-            fail(String.format("Set %s (%s) does not match array %s (%s)", types, types.size(), requiredTypeList,
+        if (types.size() != requiredTypes.length || !types.containsAll(requiredTypeList)) {
+            fail(String.format("Collection %s (%s) does not match array %s (%s)", types, types.size(), requiredTypeList,
                     requiredTypeList.size()));
         }
     }
-
-    /**
-     *
-     * @param types
-     * @param requiredTypes
-     */
-    public static void assertTypeListMatches(List<? extends Type> types, Type... requiredTypes) {
-
-        if (types == null) {
-            throw new IllegalArgumentException();
-        }
-
-        List<Type> requiredTypeList = Arrays.asList(requiredTypes);
-
-        if (requiredTypes.length != types.size() || !types.containsAll(requiredTypeList)) {
-            fail(String.format("List %s (%s) does not match array %s (%s)", types, types.size(), requiredTypeList,
-                    requiredTypeList.size()));
-        }
-    }
-
-    /**
-     * Helper method to compare 2 Annotated. They don't necessarily implement equals()/hashcode() so we need to
-     * compare the underlying java.lang.reflect objects.
-     *
-     * @param expected The expected Annotated instance
-     * @param actual The actual Annotated instance to compare
-     */
-    public static void assertAnnotated(final Annotated expected, final Annotated actual) {
-        assertEquals(unwrap(expected), unwrap(actual));
-    }
-
-    private static Object unwrap(final Annotated annotated) {
-        if (annotated instanceof AnnotatedMember) {
-            return ((AnnotatedMember) annotated).getJavaMember();
-        } else if (annotated instanceof AnnotatedParameter) {
-            return ((AnnotatedParameter) annotated).getJavaParameter();
-        } else if (annotated instanceof AnnotatedType) {
-            return ((AnnotatedType) annotated).getJavaClass();
-        } else {
-            throw new UnsupportedOperationException("Unknown Annotated instance: " + annotated);
-        }
-    }
-
 }

--- a/impl/src/test/java/org/jboss/cdi/tck/test/util/AssertTest.java
+++ b/impl/src/test/java/org/jboss/cdi/tck/test/util/AssertTest.java
@@ -14,8 +14,10 @@
 
 package org.jboss.cdi.tck.test.util;
 
+import static org.jboss.cdi.tck.util.Assert.assertAnnotationsMatch;
+import static org.jboss.cdi.tck.util.Assert.assertTypesMatch;
+
 import java.lang.annotation.Annotation;
-import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -27,7 +29,6 @@ import jakarta.enterprise.inject.literal.InjectLiteral;
 import jakarta.enterprise.util.TypeLiteral;
 import jakarta.inject.Inject;
 
-import org.jboss.cdi.tck.util.Assert;
 import org.testng.annotations.Test;
 
 /**
@@ -36,72 +37,65 @@ import org.testng.annotations.Test;
  */
 public class AssertTest {
 
-    @SuppressWarnings("unchecked")
     @Test
     public void testAnnotationSetMatches() {
-        Set<Annotation> annotations = new HashSet<Annotation>();
+        Set<Annotation> annotations = new HashSet<>();
         annotations.add(Any.Literal.INSTANCE);
         annotations.add(InjectLiteral.INSTANCE);
-        Assert.assertAnnotationSetMatches(annotations, Any.class, Inject.class);
+        assertAnnotationsMatch(annotations, Any.class, Inject.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expectedExceptions = AssertionError.class)
     public void testAnnotationSetDoesNotMatchA() {
-        Set<Annotation> annotations = new HashSet<Annotation>();
+        Set<Annotation> annotations = new HashSet<>();
         annotations.add(Any.Literal.INSTANCE);
         annotations.add(InjectLiteral.INSTANCE);
-        Assert.assertAnnotationSetMatches(annotations, Any.class);
+        assertAnnotationsMatch(annotations, Any.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expectedExceptions = AssertionError.class)
     public void testAnnotationSetDoesNotMatchB() {
-        Set<Annotation> annotations = new HashSet<Annotation>();
+        Set<Annotation> annotations = new HashSet<>();
         annotations.add(InjectLiteral.INSTANCE);
-        Assert.assertAnnotationSetMatches(annotations, Any.class, Inject.class);
+        assertAnnotationsMatch(annotations, Any.class, Inject.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expectedExceptions = AssertionError.class)
     public void testAnnotationSetDoesNotMatchC() {
-        Set<Annotation> annotations = new HashSet<Annotation>();
+        Set<Annotation> annotations = new HashSet<>();
         annotations.add(Any.Literal.INSTANCE);
         annotations.add(InjectLiteral.INSTANCE);
-        Assert.assertAnnotationSetMatches(annotations, Any.class, Default.class);
+        assertAnnotationsMatch(annotations, Any.class, Default.class);
     }
 
     @SuppressWarnings("unchecked")
     @Test
     public void testAnnotationSetIsEmptyAndRequiredAnnotationsEmpty() {
-        Assert.assertAnnotationSetMatches(new HashSet<Annotation>());
+        assertAnnotationsMatch(new HashSet<>(), new Class[0]);
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expectedExceptions = AssertionError.class)
     public void testAnnotationSetIsEmpty() {
-        Assert.assertAnnotationSetMatches(new HashSet<Annotation>(), Any.class);
+        assertAnnotationsMatch(new HashSet<>(), Any.class);
     }
 
     @SuppressWarnings("unchecked")
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testAnnotationSetIsNull() {
-        Assert.assertAnnotationSetMatches(null);
+        assertAnnotationsMatch(null, new Class[0]);
     }
 
-    @SuppressWarnings("serial")
     @Test(expectedExceptions = AssertionError.class)
-    public void testTypeSetDoeNotMatch() {
-        Assert.assertTypeSetMatches(new HashSet<Type>(Arrays.asList(String.class, new TypeLiteral<List<Integer>>() {
-        }.getType())), String.class);
+    public void testTypeSetDoesNotMatch() {
+        assertTypesMatch(Arrays.asList(String.class, new TypeLiteral<List<Integer>>() {
+        }.getType()), String.class);
     }
 
-    @SuppressWarnings("serial")
     @Test
     public void testTypeSetMatches() {
-        Assert.assertTypeSetMatches(
-                new HashSet<Type>(Arrays.asList(Integer.class, String.class, new TypeLiteral<List<Boolean>>() {
-                }.getType())), String.class, Integer.class, new TypeLiteral<List<Boolean>>() {
+        assertTypesMatch(
+                Arrays.asList(Integer.class, String.class, new TypeLiteral<List<Boolean>>() {
+                }.getType()), String.class, Integer.class, new TypeLiteral<List<Boolean>>() {
                 }.getType());
     }
 }


### PR DESCRIPTION
All tests now use assertion methods from `org.jboss.cdi.tck.Assert`. The helper methods on `AbstractTest`, which were in all but 1 cases used just as an argument to `assertTrue()`, are removed.

There was one bug in `AbstractTest.annotationSetMatches()` that is fixed now: the method asserted correct number of elements, but didn't assert correct elements themselves. This bugfix may reveal issues in implementations, but ArC and Weld are correct. Further, the `ProducerMethodWithDefaultNameTest.testProducerMethodQualifiers()` test was wrong (fortunately, all other tests were fine): it asserted that the producer method bean has qualifiers `Any` and `Default`, while it should have `Any` and `Funny`. This bug is fixed as well.