### PR TITLE
Add TCK tests for SyntheticBeanBuilder.withInjectionPoint()

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjections/Alpha.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjections/Alpha.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjections;
+
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
+public class Alpha {
+    public String value() {
+        return "alpha";
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjections/Bravo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjections/Bravo.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjections;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class Bravo {
+    public String value() {
+        return "bravo";
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjections/SyntheticInjectionsExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjections/SyntheticInjectionsExtension.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjections;
+
+import java.lang.annotation.Annotation;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;
+import jakarta.enterprise.inject.build.compatible.spi.Synthesis;
+import jakarta.enterprise.inject.build.compatible.spi.SyntheticComponents;
+
+public class SyntheticInjectionsExtension implements BuildCompatibleExtension {
+    @Synthesis
+    public void synthesize(SyntheticComponents syn) {
+        syn.addBean(SyntheticPojo.class)
+                .type(SyntheticPojo.class)
+                .scope(Dependent.class)
+                .withInjectionPoint(Alpha.class, new Annotation[0])
+                .withInjectionPoint(Bravo.class, new Annotation[0])
+                .createWith(SyntheticPojoCreator.class)
+                .disposeWith(SyntheticPojoDisposer.class);
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjections/SyntheticInjectionsTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjections/SyntheticInjectionsTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjections;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import jakarta.enterprise.inject.Instance;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.cdi.tck.AbstractTest;
+import org.jboss.cdi.tck.cdi.Sections;
+import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.test.audit.annotations.SpecAssertion;
+import org.jboss.test.audit.annotations.SpecVersion;
+import org.testng.annotations.Test;
+
+@SpecVersion(spec = "cdi", version = "5.0")
+public class SyntheticInjectionsTest extends AbstractTest {
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return new WebArchiveBuilder()
+                .withTestClassPackage(SyntheticInjectionsTest.class)
+                .withBuildCompatibleExtension(SyntheticInjectionsExtension.class)
+                .build();
+    }
+
+    @Test
+    @SpecAssertion(section = Sections.SYNTHESIS_PHASE, id = "ca", note = "withInjectionPoint(Class) registers injection points")
+    @SpecAssertion(section = Sections.SYNTHESIS_PHASE, id = "cb", note = "no qualifier passed, @Default is assumed")
+    @SpecAssertion(section = Sections.SYNTHESIS_PHASE, id = "cd", note = "SyntheticInjections used in creator")
+    public void testCreatorReceivesInjections() {
+        Instance<Object> lookup = getCurrentBeanContainer().createInstance();
+        Instance.Handle<SyntheticPojo> handle = lookup.select(SyntheticPojo.class).getHandle();
+        SyntheticPojo pojo = handle.get();
+        assertEquals(pojo.alphaValue, "alpha");
+        assertEquals(pojo.bravoValue, "bravo");
+        handle.destroy();
+    }
+
+    @Test
+    @SpecAssertion(section = Sections.SYNTHESIS_PHASE, id = "ce", note = "SyntheticInjections used in disposer")
+    public void testDisposerReceivesInjections() {
+        Instance<Object> lookup = getCurrentBeanContainer().createInstance();
+        Instance.Handle<SyntheticPojo> handle = lookup.select(SyntheticPojo.class).getHandle();
+        handle.get();
+        SyntheticPojoDisposer.disposed.set(false);
+        SyntheticPojoDisposer.bravoValueInDisposer = null;
+        handle.destroy();
+        assertTrue(SyntheticPojoDisposer.disposed.get());
+        assertEquals(SyntheticPojoDisposer.bravoValueInDisposer, "bravo");
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjections/SyntheticPojo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjections/SyntheticPojo.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjections;
+
+public class SyntheticPojo {
+    public final String alphaValue;
+    public final String bravoValue;
+
+    public SyntheticPojo(String alphaValue, String bravoValue) {
+        this.alphaValue = alphaValue;
+        this.bravoValue = bravoValue;
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjections/SyntheticPojoCreator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjections/SyntheticPojoCreator.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjections;
+
+import jakarta.enterprise.inject.build.compatible.spi.Parameters;
+import jakarta.enterprise.inject.build.compatible.spi.SyntheticBeanCreator;
+import jakarta.enterprise.inject.build.compatible.spi.SyntheticInjections;
+
+public class SyntheticPojoCreator implements SyntheticBeanCreator<SyntheticPojo> {
+    @Override
+    public SyntheticPojo create(SyntheticInjections injections, Parameters params) {
+        Alpha alpha = injections.get(Alpha.class);
+        Bravo bravo = injections.get(Bravo.class);
+        return new SyntheticPojo(alpha.value(), bravo.value());
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjections/SyntheticPojoDisposer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjections/SyntheticPojoDisposer.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjections;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import jakarta.enterprise.inject.build.compatible.spi.Parameters;
+import jakarta.enterprise.inject.build.compatible.spi.SyntheticBeanDisposer;
+import jakarta.enterprise.inject.build.compatible.spi.SyntheticInjections;
+
+public class SyntheticPojoDisposer implements SyntheticBeanDisposer<SyntheticPojo> {
+    static final AtomicBoolean disposed = new AtomicBoolean(false);
+    static String bravoValueInDisposer = null;
+
+    @Override
+    public void dispose(SyntheticPojo instance, SyntheticInjections injections, Parameters params) {
+        Bravo bravo = injections.get(Bravo.class);
+        bravoValueInDisposer = bravo.value();
+        disposed.set(true);
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsAnnotationInfo/AnnotationInfoExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsAnnotationInfo/AnnotationInfoExtension.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsAnnotationInfo;
+
+import java.lang.annotation.Annotation;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.build.compatible.spi.AnnotationBuilder;
+import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;
+import jakarta.enterprise.inject.build.compatible.spi.Synthesis;
+import jakarta.enterprise.inject.build.compatible.spi.SyntheticComponents;
+
+public class AnnotationInfoExtension implements BuildCompatibleExtension {
+    @Synthesis
+    public void synthesize(SyntheticComponents syn) {
+        syn.addBean(SyntheticPojo.class)
+                .type(SyntheticPojo.class)
+                .scope(Dependent.class)
+                .withInjectionPoint(Widget.class, new Annotation[0])
+                .withInjectionPoint(Widget.class, AnnotationBuilder.of(Nice.class).build())
+                .createWith(SyntheticPojoCreator.class);
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsAnnotationInfo/Nice.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsAnnotationInfo/Nice.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsAnnotationInfo;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.inject.Qualifier;
+
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER })
+public @interface Nice {
+    final class Literal extends AnnotationLiteral<Nice> implements Nice {
+        public static final Literal INSTANCE = new Literal();
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsAnnotationInfo/NiceWidget.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsAnnotationInfo/NiceWidget.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsAnnotationInfo;
+
+import jakarta.enterprise.context.Dependent;
+
+@Nice
+@Dependent
+public class NiceWidget implements Widget {
+    @Override
+    public String name() {
+        return "nice";
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsAnnotationInfo/PlainWidget.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsAnnotationInfo/PlainWidget.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsAnnotationInfo;
+
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
+public class PlainWidget implements Widget {
+    @Override
+    public String name() {
+        return "plain";
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsAnnotationInfo/SyntheticInjectionsAnnotationInfoTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsAnnotationInfo/SyntheticInjectionsAnnotationInfoTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsAnnotationInfo;
+
+import static org.testng.Assert.assertEquals;
+
+import jakarta.enterprise.inject.Instance;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.cdi.tck.AbstractTest;
+import org.jboss.cdi.tck.cdi.Sections;
+import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.test.audit.annotations.SpecAssertion;
+import org.jboss.test.audit.annotations.SpecVersion;
+import org.testng.annotations.Test;
+
+@SpecVersion(spec = "cdi", version = "5.0")
+public class SyntheticInjectionsAnnotationInfoTest extends AbstractTest {
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return new WebArchiveBuilder()
+                .withTestClassPackage(SyntheticInjectionsAnnotationInfoTest.class)
+                .withBuildCompatibleExtension(AnnotationInfoExtension.class)
+                .build();
+    }
+
+    @Test
+    @SpecAssertion(section = Sections.SYNTHESIS_PHASE, id = "ca", note = "withInjectionPoint(Class, AnnotationInfo...) overload")
+    @SpecAssertion(section = Sections.SYNTHESIS_PHASE, id = "cl", note = "AnnotationInfo qualifier distinguishes beans")
+    public void testAnnotationInfoQualifier() {
+        Instance<Object> lookup = getCurrentBeanContainer().createInstance();
+        Instance.Handle<SyntheticPojo> handle = lookup.select(SyntheticPojo.class).getHandle();
+        SyntheticPojo pojo = handle.get();
+        assertEquals(pojo.plainName, "plain");
+        assertEquals(pojo.niceName, "nice");
+        handle.destroy();
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsAnnotationInfo/SyntheticPojo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsAnnotationInfo/SyntheticPojo.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsAnnotationInfo;
+
+public class SyntheticPojo {
+    public final String plainName;
+    public final String niceName;
+
+    public SyntheticPojo(String plainName, String niceName) {
+        this.plainName = plainName;
+        this.niceName = niceName;
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsAnnotationInfo/SyntheticPojoCreator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsAnnotationInfo/SyntheticPojoCreator.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsAnnotationInfo;
+
+import jakarta.enterprise.inject.build.compatible.spi.Parameters;
+import jakarta.enterprise.inject.build.compatible.spi.SyntheticBeanCreator;
+import jakarta.enterprise.inject.build.compatible.spi.SyntheticInjections;
+
+public class SyntheticPojoCreator implements SyntheticBeanCreator<SyntheticPojo> {
+    @Override
+    public SyntheticPojo create(SyntheticInjections injections, Parameters params) {
+        Widget plain = injections.get(Widget.class);
+        Widget nice = injections.get(Widget.class, Nice.Literal.INSTANCE);
+        return new SyntheticPojo(plain.name(), nice.name());
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsAnnotationInfo/Widget.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsAnnotationInfo/Widget.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsAnnotationInfo;
+
+public interface Widget {
+    String name();
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsDependent/SyntheticInjectionsDependentExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsDependent/SyntheticInjectionsDependentExtension.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsDependent;
+
+import java.lang.annotation.Annotation;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;
+import jakarta.enterprise.inject.build.compatible.spi.Synthesis;
+import jakarta.enterprise.inject.build.compatible.spi.SyntheticComponents;
+
+public class SyntheticInjectionsDependentExtension implements BuildCompatibleExtension {
+    @Synthesis
+    public void synthesize(SyntheticComponents syn) {
+        syn.addBean(SyntheticPojo.class)
+                .type(SyntheticPojo.class)
+                .scope(Dependent.class)
+                .withInjectionPoint(TrackedBean.class, new Annotation[0])
+                .createWith(SyntheticPojoCreator.class)
+                .disposeWith(SyntheticPojoDisposer.class);
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsDependent/SyntheticInjectionsDependentTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsDependent/SyntheticInjectionsDependentTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsDependent;
+
+import static org.testng.Assert.assertEquals;
+
+import jakarta.enterprise.inject.Instance;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.cdi.tck.AbstractTest;
+import org.jboss.cdi.tck.cdi.Sections;
+import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.test.audit.annotations.SpecAssertion;
+import org.jboss.test.audit.annotations.SpecVersion;
+import org.testng.annotations.Test;
+
+@SpecVersion(spec = "cdi", version = "5.0")
+public class SyntheticInjectionsDependentTest extends AbstractTest {
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return new WebArchiveBuilder()
+                .withTestClassPackage(SyntheticInjectionsDependentTest.class)
+                .withBuildCompatibleExtension(SyntheticInjectionsDependentExtension.class)
+                .build();
+    }
+
+    @Test
+    @SpecAssertion(section = Sections.SYNTHESIS_PHASE, id = "ch", note = "@Dependent beans from SyntheticInjections destroyed with synthetic bean")
+    public void testDependentBeanLifecycle() {
+        TrackedBean.reset();
+        SyntheticPojo.reset();
+
+        Instance<Object> lookup = getCurrentBeanContainer().createInstance();
+
+        assertEquals(TrackedBean.createdCount.get(), 0);
+        assertEquals(TrackedBean.destroyedCount.get(), 0);
+
+        Instance.Handle<SyntheticPojo> handle = lookup.select(SyntheticPojo.class).getHandle();
+        handle.get();
+
+        // TrackedBean was obtained during creation
+        assertEquals(TrackedBean.createdCount.get(), 1);
+        assertEquals(TrackedBean.destroyedCount.get(), 0);
+
+        handle.destroy();
+
+        // After synthetic bean destruction:
+        // - TrackedBean created in creator should be destroyed
+        // - TrackedBean created in disposer is also destroyed (disposer dependents
+        //   are destroyed when disposal completes)
+        assertEquals(TrackedBean.createdCount.get(), 2);
+        assertEquals(TrackedBean.destroyedCount.get(), 2);
+        assertEquals(SyntheticPojo.destroyedCount.get(), 1);
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsDependent/SyntheticPojo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsDependent/SyntheticPojo.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsDependent;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class SyntheticPojo {
+    static final AtomicInteger createdCount = new AtomicInteger(0);
+    static final AtomicInteger destroyedCount = new AtomicInteger(0);
+
+    static void reset() {
+        createdCount.set(0);
+        destroyedCount.set(0);
+    }
+
+    public SyntheticPojo() {
+        createdCount.incrementAndGet();
+    }
+
+    public void destroy() {
+        destroyedCount.incrementAndGet();
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsDependent/SyntheticPojoCreator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsDependent/SyntheticPojoCreator.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsDependent;
+
+import jakarta.enterprise.inject.build.compatible.spi.Parameters;
+import jakarta.enterprise.inject.build.compatible.spi.SyntheticBeanCreator;
+import jakarta.enterprise.inject.build.compatible.spi.SyntheticInjections;
+
+public class SyntheticPojoCreator implements SyntheticBeanCreator<SyntheticPojo> {
+    @Override
+    public SyntheticPojo create(SyntheticInjections injections, Parameters params) {
+        TrackedBean tracked = injections.get(TrackedBean.class);
+        tracked.ping();
+        return new SyntheticPojo();
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsDependent/SyntheticPojoDisposer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsDependent/SyntheticPojoDisposer.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsDependent;
+
+import jakarta.enterprise.inject.build.compatible.spi.Parameters;
+import jakarta.enterprise.inject.build.compatible.spi.SyntheticBeanDisposer;
+import jakarta.enterprise.inject.build.compatible.spi.SyntheticInjections;
+
+public class SyntheticPojoDisposer implements SyntheticBeanDisposer<SyntheticPojo> {
+    @Override
+    public void dispose(SyntheticPojo instance, SyntheticInjections injections, Parameters params) {
+        TrackedBean tracked = injections.get(TrackedBean.class);
+        tracked.ping();
+        instance.destroy();
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsDependent/TrackedBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsDependent/TrackedBean.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsDependent;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
+public class TrackedBean {
+    static final AtomicInteger createdCount = new AtomicInteger(0);
+    static final AtomicInteger destroyedCount = new AtomicInteger(0);
+
+    static void reset() {
+        createdCount.set(0);
+        destroyedCount.set(0);
+    }
+
+    @PostConstruct
+    void postConstruct() {
+        createdCount.incrementAndGet();
+    }
+
+    @PreDestroy
+    void preDestroy() {
+        destroyedCount.incrementAndGet();
+    }
+
+    public String ping() {
+        return "tracked";
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsInjectionPoint/MyQualifier.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsInjectionPoint/MyQualifier.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsInjectionPoint;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.enterprise.util.Nonbinding;
+import jakarta.inject.Qualifier;
+
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER })
+public @interface MyQualifier {
+    String binding();
+
+    @Nonbinding
+    String nonBinding();
+
+    final class Literal extends AnnotationLiteral<MyQualifier> implements MyQualifier {
+        private final String binding;
+        private final String nonBinding;
+
+        public Literal(String binding, String nonBinding) {
+            this.binding = binding;
+            this.nonBinding = nonBinding;
+        }
+
+        @Override
+        public String binding() {
+            return binding;
+        }
+
+        @Override
+        public String nonBinding() {
+            return nonBinding;
+        }
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsInjectionPoint/PojoConsumer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsInjectionPoint/PojoConsumer.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsInjectionPoint;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Inject;
+
+@Dependent
+public class PojoConsumer {
+    @Inject
+    SyntheticPojo pojo;
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsInjectionPoint/SyntheticInjectionsInjectionPointExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsInjectionPoint/SyntheticInjectionsInjectionPointExtension.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsInjectionPoint;
+
+import java.lang.annotation.Annotation;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;
+import jakarta.enterprise.inject.build.compatible.spi.Synthesis;
+import jakarta.enterprise.inject.build.compatible.spi.SyntheticComponents;
+import jakarta.enterprise.inject.spi.InjectionPoint;
+
+public class SyntheticInjectionsInjectionPointExtension implements BuildCompatibleExtension {
+    @Synthesis
+    public void synthesize(SyntheticComponents syn) {
+        syn.addBean(SyntheticPojo.class)
+                .type(SyntheticPojo.class)
+                .scope(Dependent.class)
+                .withInjectionPoint(InjectionPoint.class, new Annotation[0])
+                .createWith(SyntheticPojoCreator.class)
+                .disposeWith(SyntheticPojoDisposer.class);
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsInjectionPoint/SyntheticInjectionsInjectionPointTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsInjectionPoint/SyntheticInjectionsInjectionPointTest.java
@@ -10,8 +10,11 @@
 package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsInjectionPoint;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
+
+import java.lang.annotation.Annotation;
 
 import jakarta.enterprise.inject.Instance;
 
@@ -43,6 +46,23 @@ public class SyntheticInjectionsInjectionPointTest extends AbstractTest {
         assertNotNull(consumer.pojo);
         assertNotNull(consumer.pojo.injectionPoint);
         assertEquals(consumer.pojo.injectionPoint.getType(), SyntheticPojo.class);
+
+        MyQualifier qualifier = null;
+        for (Annotation a : consumer.pojo.injectionPoint.getQualifiers()) {
+            if (a instanceof MyQualifier) {
+                qualifier = (MyQualifier) a;
+            }
+        }
+        assertNotNull(qualifier);
+        assertEquals(qualifier.binding(), "alpha");
+        assertEquals(qualifier.nonBinding(), "bravo");
+
+        assertNotNull(consumer.pojo.injectionPoint.getBean());
+        assertEquals(consumer.pojo.injectionPoint.getBean().getBeanClass(), PojoConsumer.class);
+        assertFalse(consumer.pojo.injectionPoint.isDelegate());
+        assertFalse(consumer.pojo.injectionPoint.isTransient());
+        assertNotNull(consumer.pojo.injectionPoint.getMember());
+        assertNotNull(consumer.pojo.injectionPoint.getAnnotated());
         handle.destroy();
     }
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsInjectionPoint/SyntheticInjectionsInjectionPointTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsInjectionPoint/SyntheticInjectionsInjectionPointTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsInjectionPoint;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+import jakarta.enterprise.inject.Instance;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.cdi.tck.AbstractTest;
+import org.jboss.cdi.tck.cdi.Sections;
+import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.test.audit.annotations.SpecAssertion;
+import org.jboss.test.audit.annotations.SpecVersion;
+import org.testng.annotations.Test;
+
+@SpecVersion(spec = "cdi", version = "5.0")
+public class SyntheticInjectionsInjectionPointTest extends AbstractTest {
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return new WebArchiveBuilder()
+                .withTestClassPackage(SyntheticInjectionsInjectionPointTest.class)
+                .withBuildCompatibleExtension(SyntheticInjectionsInjectionPointExtension.class)
+                .build();
+    }
+
+    @Test
+    @SpecAssertion(section = Sections.SYNTHESIS_PHASE, id = "ci", note = "@Dependent synthetic bean can obtain InjectionPoint from SyntheticInjections")
+    public void testInjectionPointLookup() {
+        Instance<Object> lookup = getCurrentBeanContainer().createInstance();
+        Instance.Handle<PojoConsumer> handle = lookup.select(PojoConsumer.class).getHandle();
+        PojoConsumer consumer = handle.get();
+        assertNotNull(consumer.pojo);
+        assertNotNull(consumer.pojo.injectionPoint);
+        assertEquals(consumer.pojo.injectionPoint.getType(), SyntheticPojo.class);
+        handle.destroy();
+    }
+
+    @Test
+    @SpecAssertion(section = Sections.SYNTHESIS_PHASE, id = "ci", note = "InjectionPoint lookup in disposer via SyntheticInjections is invalid")
+    public void testDisposerInjectionPointLookupIsInvalid() {
+        Instance<Object> lookup = getCurrentBeanContainer().createInstance();
+
+        SyntheticPojoDisposer.lookedUp = null;
+
+        Instance.Handle<PojoConsumer> handle = lookup.select(PojoConsumer.class).getHandle();
+        handle.get();
+
+        handle.destroy();
+
+        assertNull(SyntheticPojoDisposer.lookedUp);
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsInjectionPoint/SyntheticPojo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsInjectionPoint/SyntheticPojo.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsInjectionPoint;
+
+import jakarta.enterprise.inject.spi.InjectionPoint;
+
+public class SyntheticPojo {
+    public final InjectionPoint injectionPoint;
+
+    public SyntheticPojo(InjectionPoint injectionPoint) {
+        this.injectionPoint = injectionPoint;
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsInjectionPoint/SyntheticPojoCreator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsInjectionPoint/SyntheticPojoCreator.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsInjectionPoint;
+
+import jakarta.enterprise.inject.build.compatible.spi.Parameters;
+import jakarta.enterprise.inject.build.compatible.spi.SyntheticBeanCreator;
+import jakarta.enterprise.inject.build.compatible.spi.SyntheticInjections;
+import jakarta.enterprise.inject.spi.InjectionPoint;
+
+public class SyntheticPojoCreator implements SyntheticBeanCreator<SyntheticPojo> {
+    @Override
+    public SyntheticPojo create(SyntheticInjections injections, Parameters params) {
+        InjectionPoint ip = injections.get(InjectionPoint.class);
+        return new SyntheticPojo(ip);
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsInjectionPoint/SyntheticPojoDisposer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsInjectionPoint/SyntheticPojoDisposer.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsInjectionPoint;
+
+import jakarta.enterprise.inject.build.compatible.spi.Parameters;
+import jakarta.enterprise.inject.build.compatible.spi.SyntheticBeanDisposer;
+import jakarta.enterprise.inject.build.compatible.spi.SyntheticInjections;
+import jakarta.enterprise.inject.spi.InjectionPoint;
+
+public class SyntheticPojoDisposer implements SyntheticBeanDisposer<SyntheticPojo> {
+    static InjectionPoint lookedUp = null;
+
+    @Override
+    public void dispose(SyntheticPojo instance, SyntheticInjections injections, Parameters params) {
+        try {
+            lookedUp = injections.get(InjectionPoint.class);
+        } catch (Exception ignored) {
+            // The spec says looking up InjectionPoint in a disposer is "invalid".
+            // The container may throw any exception.
+        }
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsInjectionPointIndirect/MyService.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsInjectionPointIndirect/MyService.java
@@ -7,14 +7,14 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsInjectionPoint;
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsInjectionPointIndirect;
 
 import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.spi.InjectionPoint;
 import jakarta.inject.Inject;
 
 @Dependent
-public class PojoConsumer {
+public class MyService {
     @Inject
-    @MyQualifier(binding = "alpha", nonBinding = "bravo")
-    SyntheticPojo pojo;
+    InjectionPoint injectionPoint;
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsInjectionPointIndirect/SyntheticInjectionsIndirectInjectionPointExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsInjectionPointIndirect/SyntheticInjectionsIndirectInjectionPointExtension.java
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsInjectionPoint;
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsInjectionPointIndirect;
 
 import java.lang.annotation.Annotation;
 
@@ -15,17 +15,14 @@ import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;
 import jakarta.enterprise.inject.build.compatible.spi.Synthesis;
 import jakarta.enterprise.inject.build.compatible.spi.SyntheticComponents;
-import jakarta.enterprise.inject.spi.InjectionPoint;
 
-public class SyntheticInjectionsInjectionPointExtension implements BuildCompatibleExtension {
+public class SyntheticInjectionsIndirectInjectionPointExtension implements BuildCompatibleExtension {
     @Synthesis
     public void synthesize(SyntheticComponents syn) {
         syn.addBean(SyntheticPojo.class)
                 .type(SyntheticPojo.class)
                 .scope(Dependent.class)
-                .qualifier(new MyQualifier.Literal("alpha", ""))
-                .withInjectionPoint(InjectionPoint.class, new Annotation[0])
-                .createWith(SyntheticPojoCreator.class)
-                .disposeWith(SyntheticPojoDisposer.class);
+                .withInjectionPoint(MyService.class, new Annotation[0])
+                .createWith(SyntheticPojoCreator.class);
     }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsInjectionPointIndirect/SyntheticInjectionsIndirectInjectionPointTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsInjectionPointIndirect/SyntheticInjectionsIndirectInjectionPointTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsInjectionPointIndirect;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import jakarta.enterprise.inject.Default;
+import jakarta.enterprise.inject.Instance;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.cdi.tck.AbstractTest;
+import org.jboss.cdi.tck.cdi.Sections;
+import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.test.audit.annotations.SpecAssertion;
+import org.jboss.test.audit.annotations.SpecVersion;
+import org.testng.annotations.Test;
+
+@SpecVersion(spec = "cdi", version = "5.0")
+public class SyntheticInjectionsIndirectInjectionPointTest extends AbstractTest {
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return new WebArchiveBuilder()
+                .withTestClassPackage(SyntheticInjectionsIndirectInjectionPointTest.class)
+                .withBuildCompatibleExtension(SyntheticInjectionsIndirectInjectionPointExtension.class)
+                .build();
+    }
+
+    @Test
+    @SpecAssertion(section = Sections.SYNTHESIS_PHASE, id = "ci", note = "InjectionPoint metadata is available for a dependent bean injected into a synthetic bean")
+    public void testIndirectInjectionPoint() {
+        Instance<Object> lookup = getCurrentBeanContainer().createInstance();
+        Instance.Handle<SyntheticPojo> handle = lookup.select(SyntheticPojo.class).getHandle();
+        SyntheticPojo pojo = handle.get();
+
+        assertNotNull(pojo.serviceInjectionPoint);
+        assertEquals(pojo.serviceInjectionPoint.getType(), MyService.class);
+        assertTrue(pojo.serviceInjectionPoint.getQualifiers().contains(Default.Literal.INSTANCE));
+        assertNotNull(pojo.serviceInjectionPoint.getBean());
+        assertEquals(pojo.serviceInjectionPoint.getBean().getBeanClass(), SyntheticPojo.class);
+        assertFalse(pojo.serviceInjectionPoint.isDelegate());
+        assertFalse(pojo.serviceInjectionPoint.isTransient());
+        assertNull(pojo.serviceInjectionPoint.getAnnotated());
+        assertNull(pojo.serviceInjectionPoint.getMember());
+
+        handle.destroy();
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsInjectionPointIndirect/SyntheticPojo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsInjectionPointIndirect/SyntheticPojo.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsInjectionPointIndirect;
+
+import jakarta.enterprise.inject.spi.InjectionPoint;
+
+public class SyntheticPojo {
+    public final InjectionPoint serviceInjectionPoint;
+
+    public SyntheticPojo(InjectionPoint serviceInjectionPoint) {
+        this.serviceInjectionPoint = serviceInjectionPoint;
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsInjectionPointIndirect/SyntheticPojoCreator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsInjectionPointIndirect/SyntheticPojoCreator.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsInjectionPointIndirect;
+
+import jakarta.enterprise.inject.build.compatible.spi.Parameters;
+import jakarta.enterprise.inject.build.compatible.spi.SyntheticBeanCreator;
+import jakarta.enterprise.inject.build.compatible.spi.SyntheticInjections;
+
+public class SyntheticPojoCreator implements SyntheticBeanCreator<SyntheticPojo> {
+    @Override
+    public SyntheticPojo create(SyntheticInjections injections, Parameters params) {
+        MyService service = injections.get(MyService.class);
+        return new SyntheticPojo(service.injectionPoint);
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsQualifier/DefaultService.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsQualifier/DefaultService.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsQualifier;
+
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
+public class DefaultService implements MyService {
+    @Override
+    public String id() {
+        return "default";
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsQualifier/MyService.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsQualifier/MyService.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsQualifier;
+
+public interface MyService {
+    String id();
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsQualifier/Special.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsQualifier/Special.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsQualifier;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.inject.Qualifier;
+
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER })
+public @interface Special {
+    final class Literal extends AnnotationLiteral<Special> implements Special {
+        public static final Literal INSTANCE = new Literal();
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsQualifier/SpecialService.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsQualifier/SpecialService.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsQualifier;
+
+import jakarta.enterprise.context.Dependent;
+
+@Special
+@Dependent
+public class SpecialService implements MyService {
+    @Override
+    public String id() {
+        return "special";
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsQualifier/SyntheticInjectionsQualifierExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsQualifier/SyntheticInjectionsQualifierExtension.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsQualifier;
+
+import java.lang.annotation.Annotation;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;
+import jakarta.enterprise.inject.build.compatible.spi.Synthesis;
+import jakarta.enterprise.inject.build.compatible.spi.SyntheticComponents;
+
+public class SyntheticInjectionsQualifierExtension implements BuildCompatibleExtension {
+    @Synthesis
+    public void synthesize(SyntheticComponents syn) {
+        syn.addBean(SyntheticPojo.class)
+                .type(SyntheticPojo.class)
+                .scope(Dependent.class)
+                .withInjectionPoint(MyService.class, new Annotation[0])
+                .withInjectionPoint(MyService.class, Special.Literal.INSTANCE)
+                .createWith(SyntheticPojoCreator.class);
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsQualifier/SyntheticInjectionsQualifierTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsQualifier/SyntheticInjectionsQualifierTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsQualifier;
+
+import static org.testng.Assert.assertEquals;
+
+import jakarta.enterprise.inject.Instance;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.cdi.tck.AbstractTest;
+import org.jboss.cdi.tck.cdi.Sections;
+import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.test.audit.annotations.SpecAssertion;
+import org.jboss.test.audit.annotations.SpecVersion;
+import org.testng.annotations.Test;
+
+@SpecVersion(spec = "cdi", version = "5.0")
+public class SyntheticInjectionsQualifierTest extends AbstractTest {
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return new WebArchiveBuilder()
+                .withTestClassPackage(SyntheticInjectionsQualifierTest.class)
+                .withBuildCompatibleExtension(SyntheticInjectionsQualifierExtension.class)
+                .build();
+    }
+
+    @Test
+    @SpecAssertion(section = Sections.SYNTHESIS_PHASE, id = "cl", note = "qualifier distinguishes beans in SyntheticInjections.get()")
+    @SpecAssertion(section = Sections.SYNTHESIS_PHASE, id = "cb", note = "no qualifier = @Default assumed")
+    public void testQualifiedInjections() {
+        Instance<Object> lookup = getCurrentBeanContainer().createInstance();
+        Instance.Handle<SyntheticPojo> handle = lookup.select(SyntheticPojo.class).getHandle();
+        SyntheticPojo pojo = handle.get();
+        assertEquals(pojo.defaultId, "default");
+        assertEquals(pojo.specialId, "special");
+        handle.destroy();
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsQualifier/SyntheticPojo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsQualifier/SyntheticPojo.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsQualifier;
+
+public class SyntheticPojo {
+    public final String defaultId;
+    public final String specialId;
+
+    public SyntheticPojo(String defaultId, String specialId) {
+        this.defaultId = defaultId;
+        this.specialId = specialId;
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsQualifier/SyntheticPojoCreator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsQualifier/SyntheticPojoCreator.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsQualifier;
+
+import jakarta.enterprise.inject.build.compatible.spi.Parameters;
+import jakarta.enterprise.inject.build.compatible.spi.SyntheticBeanCreator;
+import jakarta.enterprise.inject.build.compatible.spi.SyntheticInjections;
+
+public class SyntheticPojoCreator implements SyntheticBeanCreator<SyntheticPojo> {
+    @Override
+    public SyntheticPojo create(SyntheticInjections injections, Parameters params) {
+        MyService defaultSvc = injections.get(MyService.class);
+        MyService specialSvc = injections.get(MyService.class, Special.Literal.INSTANCE);
+        return new SyntheticPojo(defaultSvc.id(), specialSvc.id());
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsTypeLiteral/Converter.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsTypeLiteral/Converter.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsTypeLiteral;
+
+public interface Converter<T> {
+    String convert(T input);
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsTypeLiteral/StringConverter.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsTypeLiteral/StringConverter.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsTypeLiteral;
+
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
+public class StringConverter implements Converter<String> {
+    @Override
+    public String convert(String input) {
+        return input.toUpperCase();
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsTypeLiteral/SyntheticInjectionsTypeLiteralExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsTypeLiteral/SyntheticInjectionsTypeLiteralExtension.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsTypeLiteral;
+
+import java.lang.annotation.Annotation;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;
+import jakarta.enterprise.inject.build.compatible.spi.Synthesis;
+import jakarta.enterprise.inject.build.compatible.spi.SyntheticComponents;
+import jakarta.enterprise.inject.build.compatible.spi.Types;
+import jakarta.enterprise.lang.model.types.Type;
+
+public class SyntheticInjectionsTypeLiteralExtension implements BuildCompatibleExtension {
+    @Synthesis
+    public void synthesize(SyntheticComponents syn, Types types) {
+        // Build Converter<String> as a lang model Type
+        Type converterOfString = types.parameterized(Converter.class, String.class);
+
+        syn.addBean(SyntheticPojo.class)
+                .type(SyntheticPojo.class)
+                .scope(Dependent.class)
+                .withInjectionPoint(converterOfString, new Annotation[0])
+                .createWith(SyntheticPojoCreator.class);
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsTypeLiteral/SyntheticInjectionsTypeLiteralTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsTypeLiteral/SyntheticInjectionsTypeLiteralTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsTypeLiteral;
+
+import static org.testng.Assert.assertEquals;
+
+import jakarta.enterprise.inject.Instance;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.cdi.tck.AbstractTest;
+import org.jboss.cdi.tck.cdi.Sections;
+import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.test.audit.annotations.SpecAssertion;
+import org.jboss.test.audit.annotations.SpecVersion;
+import org.testng.annotations.Test;
+
+@SpecVersion(spec = "cdi", version = "5.0")
+public class SyntheticInjectionsTypeLiteralTest extends AbstractTest {
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return new WebArchiveBuilder()
+                .withTestClassPackage(SyntheticInjectionsTypeLiteralTest.class)
+                .withBuildCompatibleExtension(SyntheticInjectionsTypeLiteralExtension.class)
+                .build();
+    }
+
+    @Test
+    @SpecAssertion(section = Sections.SYNTHESIS_PHASE, id = "cg", note = "TypeLiteral used to look up parameterized type")
+    @SpecAssertion(section = Sections.SYNTHESIS_PHASE, id = "ca", note = "withInjectionPoint(Type) registers parameterized type")
+    public void testTypeLiteralInjection() {
+        Instance<Object> lookup = getCurrentBeanContainer().createInstance();
+        Instance.Handle<SyntheticPojo> handle = lookup.select(SyntheticPojo.class).getHandle();
+        SyntheticPojo pojo = handle.get();
+        assertEquals(pojo.convertedValue, "HELLO");
+        handle.destroy();
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsTypeLiteral/SyntheticPojo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsTypeLiteral/SyntheticPojo.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsTypeLiteral;
+
+public class SyntheticPojo {
+    public final String convertedValue;
+
+    public SyntheticPojo(String convertedValue) {
+        this.convertedValue = convertedValue;
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsTypeLiteral/SyntheticPojoCreator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsTypeLiteral/SyntheticPojoCreator.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsTypeLiteral;
+
+import jakarta.enterprise.inject.build.compatible.spi.Parameters;
+import jakarta.enterprise.inject.build.compatible.spi.SyntheticBeanCreator;
+import jakarta.enterprise.inject.build.compatible.spi.SyntheticInjections;
+import jakarta.enterprise.util.TypeLiteral;
+
+public class SyntheticPojoCreator implements SyntheticBeanCreator<SyntheticPojo> {
+    @Override
+    public SyntheticPojo create(SyntheticInjections injections, Parameters params) {
+        Converter<String> converter = injections.get(new TypeLiteral<Converter<String>>() {
+        });
+        return new SyntheticPojo(converter.convert("hello"));
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsUnregistered/RegisteredBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsUnregistered/RegisteredBean.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsUnregistered;
+
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
+public class RegisteredBean {
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsUnregistered/SyntheticInjectionsUnregisteredExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsUnregistered/SyntheticInjectionsUnregisteredExtension.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsUnregistered;
+
+import java.lang.annotation.Annotation;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;
+import jakarta.enterprise.inject.build.compatible.spi.Synthesis;
+import jakarta.enterprise.inject.build.compatible.spi.SyntheticComponents;
+
+public class SyntheticInjectionsUnregisteredExtension implements BuildCompatibleExtension {
+    @Synthesis
+    public void synthesize(SyntheticComponents syn) {
+        syn.addBean(SyntheticPojo.class)
+                .type(SyntheticPojo.class)
+                .scope(Dependent.class)
+                .withInjectionPoint(RegisteredBean.class, new Annotation[0])
+                .createWith(SyntheticPojoCreator.class);
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsUnregistered/SyntheticInjectionsUnregisteredTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsUnregistered/SyntheticInjectionsUnregisteredTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsUnregistered;
+
+import static org.testng.Assert.assertTrue;
+
+import jakarta.enterprise.inject.Instance;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.cdi.tck.AbstractTest;
+import org.jboss.cdi.tck.cdi.Sections;
+import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.test.audit.annotations.SpecAssertion;
+import org.jboss.test.audit.annotations.SpecVersion;
+import org.testng.annotations.Test;
+
+@SpecVersion(spec = "cdi", version = "5.0")
+public class SyntheticInjectionsUnregisteredTest extends AbstractTest {
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return new WebArchiveBuilder()
+                .withTestClassPackage(SyntheticInjectionsUnregisteredTest.class)
+                .withBuildCompatibleExtension(SyntheticInjectionsUnregisteredExtension.class)
+                .build();
+    }
+
+    @Test
+    @SpecAssertion(section = Sections.SYNTHESIS_PHASE, id = "cf", note = "SyntheticInjections.get() throws IllegalArgumentException for unregistered type")
+    public void testUnregisteredLookupThrows() {
+        Instance<Object> lookup = getCurrentBeanContainer().createInstance();
+        Instance.Handle<SyntheticPojo> handle = lookup.select(SyntheticPojo.class).getHandle();
+        handle.get();
+        assertTrue(SyntheticPojoCreator.illegalArgumentThrown,
+                "Expected IllegalArgumentException when looking up unregistered bean");
+        handle.destroy();
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsUnregistered/SyntheticPojo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsUnregistered/SyntheticPojo.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsUnregistered;
+
+public class SyntheticPojo {
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsUnregistered/SyntheticPojoCreator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsUnregistered/SyntheticPojoCreator.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsUnregistered;
+
+import jakarta.enterprise.inject.build.compatible.spi.Parameters;
+import jakarta.enterprise.inject.build.compatible.spi.SyntheticBeanCreator;
+import jakarta.enterprise.inject.build.compatible.spi.SyntheticInjections;
+
+public class SyntheticPojoCreator implements SyntheticBeanCreator<SyntheticPojo> {
+    static boolean illegalArgumentThrown = false;
+
+    @Override
+    public SyntheticPojo create(SyntheticInjections injections, Parameters params) {
+        // This should work — RegisteredBean was registered
+        injections.get(RegisteredBean.class);
+
+        // This should throw IllegalArgumentException — UnregisteredBean was NOT registered
+        try {
+            injections.get(UnregisteredBean.class);
+        } catch (IllegalArgumentException e) {
+            illegalArgumentThrown = true;
+        }
+
+        return new SyntheticPojo();
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsUnregistered/UnregisteredBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsUnregistered/UnregisteredBean.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsUnregistered;
+
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
+public class UnregisteredBean {
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsValidation/NonExistentBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsValidation/NonExistentBean.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsValidation;
+
+import jakarta.enterprise.inject.Vetoed;
+
+@Vetoed
+public class NonExistentBean {
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsValidation/SyntheticInjectionsValidationExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsValidation/SyntheticInjectionsValidationExtension.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsValidation;
+
+import java.lang.annotation.Annotation;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;
+import jakarta.enterprise.inject.build.compatible.spi.Synthesis;
+import jakarta.enterprise.inject.build.compatible.spi.SyntheticComponents;
+
+public class SyntheticInjectionsValidationExtension implements BuildCompatibleExtension {
+    @Synthesis
+    public void synthesize(SyntheticComponents syn) {
+        syn.addBean(SyntheticPojo.class)
+                .type(SyntheticPojo.class)
+                .scope(Dependent.class)
+                .withInjectionPoint(NonExistentBean.class, new Annotation[0])
+                .createWith(SyntheticPojoCreator.class);
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsValidation/SyntheticInjectionsValidationTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsValidation/SyntheticInjectionsValidationTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsValidation;
+
+import jakarta.enterprise.inject.spi.DeploymentException;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.ShouldThrowException;
+import org.jboss.cdi.tck.AbstractTest;
+import org.jboss.cdi.tck.cdi.Sections;
+import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.test.audit.annotations.SpecAssertion;
+import org.jboss.test.audit.annotations.SpecVersion;
+import org.testng.annotations.Test;
+
+@SpecVersion(spec = "cdi", version = "5.0")
+public class SyntheticInjectionsValidationTest extends AbstractTest {
+    @Deployment
+    @ShouldThrowException(DeploymentException.class)
+    public static WebArchive createTestArchive() {
+        return new WebArchiveBuilder()
+                .withTestClassPackage(SyntheticInjectionsValidationTest.class)
+                .withBuildCompatibleExtension(SyntheticInjectionsValidationExtension.class)
+                .build();
+    }
+
+    @Test
+    @SpecAssertion(section = Sections.SYNTHESIS_PHASE, id = "cc", note = "Unresolvable injection point causes deployment problem")
+    public void trigger() {
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsValidation/SyntheticPojo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsValidation/SyntheticPojo.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsValidation;
+
+public class SyntheticPojo {
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsValidation/SyntheticPojoCreator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionsValidation/SyntheticPojoCreator.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionsValidation;
+
+import jakarta.enterprise.inject.build.compatible.spi.Parameters;
+import jakarta.enterprise.inject.build.compatible.spi.SyntheticBeanCreator;
+import jakarta.enterprise.inject.build.compatible.spi.SyntheticInjections;
+
+public class SyntheticPojoCreator implements SyntheticBeanCreator<SyntheticPojo> {
+    @Override
+    public SyntheticPojo create(SyntheticInjections injections, Parameters params) {
+        return new SyntheticPojo();
+    }
+}

--- a/impl/src/main/resources/tck-audit-cdi.xml
+++ b/impl/src/main/resources/tck-audit-cdi.xml
@@ -6601,6 +6601,36 @@
         <assertion id="b">
             <text>Test that synthesis observers are notified of fired events</text>
         </assertion>
+        <assertion id="ca">
+            <text>A synthetic bean may declare injection points using |withInjectionPoint()|. These injection points are validated by the container at deployment time.</text>
+        </assertion>
+        <assertion id="cb">
+            <text>If no qualifier is passed to |withInjectionPoint()|, |@Default| is assumed.</text>
+        </assertion>
+        <assertion id="cc">
+            <text>A registered injection point for which no matching bean exists is treated as a deployment problem.</text>
+        </assertion>
+        <assertion id="cd">
+            <text>The synthetic bean creation function may accept a |SyntheticInjections| parameter to obtain injectable references for registered injection points.</text>
+        </assertion>
+        <assertion id="ce">
+            <text>The synthetic bean destruction function may accept a |SyntheticInjections| parameter to obtain injectable references for registered injection points.</text>
+        </assertion>
+        <assertion id="cf">
+            <text>|SyntheticInjections.get()| throws |IllegalArgumentException| if the type/qualifiers combination was not registered with |withInjectionPoint()|.</text>
+        </assertion>
+        <assertion id="cg">
+            <text>|SyntheticInjections.get()| may use |TypeLiteral| to look up parameterized bean types.</text>
+        </assertion>
+        <assertion id="ch">
+            <text>All |@Dependent| bean instances created by |SyntheticInjections| are destroyed when the corresponding synthetic bean instance is destroyed.</text>
+        </assertion>
+        <assertion id="ci">
+            <text>For a |@Dependent| synthetic bean, the |InjectionPoint| to which it is injected may be obtained from the |SyntheticInjections| parameter, if previously registered.</text>
+        </assertion>
+        <assertion id="cl">
+            <text>|SyntheticInjections.get()| with a qualifier retrieves the bean matching both type and qualifier.</text>
+        </assertion>
     </section>
     <section id="validation_phase" title="The @Validation phase" level="3">
         <assertion id="a">


### PR DESCRIPTION
Fixes #699 

These are created based on a set of tests I was first developing for Weld implementation.

~~For starters, it is a draft as I need to take a second look at it myself but I can't really focus on it anymore for now, so I'll try to do that tomorrow :)~~ (EDIT: done)
I tried to cover all of the various cases I could think of but I could definitely use @Ladicek to take a look if there is any other case you had in mind. 


One thing I am not really comfortable with is the fact that we now want impls to always throw exception if you ask for a type/qualifier combination that wasn't previously stated as required.
It makes sense for build-time approach with optimizations, but while implementing this in Weld, I basically have to put in place restrictions that don't make much sense - there is nothing preventing me from giving user access to the bean he previously didn't state if the bean exists.
To me, the main value lies in early validation of the requested bean in the CDI app but I am not sure I am happy with preventing user from accessing other beans should they wish to :shrug: 
WDYT @Ladicek @Azquelt, wouldn't it make more sense to require the early validation but allow to resolve any bean at your own risk?