### PR TITLE
Add profile to allow central-staging-plugins version override

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -355,6 +355,29 @@
     </scm>
 
     <profiles>
+        <!-- Temporary profile to allow overriding central-staging-plugins version via
+             -Dcentral-staging.version=... in order to test added plugin capabilities.
+             Once the parent project inherits the required version, this can be removed. -->
+        <profile>
+            <id>override-central-staging</id>
+            <activation>
+                <property>
+                    <name>central-staging.version</name>
+                </property>
+            </activation>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.eclipse.cbi.central</groupId>
+                            <artifactId>central-staging-plugins</artifactId>
+                            <version>${central-staging.version}</version>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+
         <profile>
             <id>docs</id>
             <activation>


### PR DESCRIPTION
This is temporarily required to be able to test a new version of the plugin which should allows us to promote files with additional classifiers. 

Once that version gets released and becomes a part of the parent project, we can remove this profile.
We shouldn't need this in the CDI repo as there are no files that would go unpromoted...at least so far as I could tell :)

See also https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/6890#note_7014550