### PR TITLE
Remove unused maven-release-plugin configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -227,16 +227,6 @@
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-release-plugin</artifactId>
-                    <version>3.3.1</version>
-                    <configuration>
-                        <mavenExecutorId>forked-path</mavenExecutorId>
-                        <preparationGoals>clean install</preparationGoals>
-                        <arguments>-Drelease -Dtck-audit</arguments>
-                    </configuration>
-                </plugin>
-                <plugin>
                     <groupId>jakarta.tck</groupId>
                     <artifactId>sigtest-maven-plugin</artifactId>
                     <version>2.6</version>


### PR DESCRIPTION
This configuration should no longer be needed for the release.