### PR TITLE
Add missing extension classes to invalid @Registration test deployments

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/registration/invalid/RegistrationWithRawTypeLiteralTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/registration/invalid/RegistrationWithRawTypeLiteralTest.java
@@ -28,6 +28,7 @@ public class RegistrationWithRawTypeLiteralTest extends AbstractTest {
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder()
                 .withTestClass(RegistrationWithRawTypeLiteralTest.class)
+                .withClass(RegistrationWithRawTypeLiteralExtension.class)
                 .withBuildCompatibleExtension(RegistrationWithRawTypeLiteralExtension.class)
                 .build();
     }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/registration/invalid/RegistrationWithTypeVariableTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/registration/invalid/RegistrationWithTypeVariableTest.java
@@ -30,6 +30,7 @@ public class RegistrationWithTypeVariableTest extends AbstractTest {
         return new WebArchiveBuilder()
                 .withTestClass(RegistrationWithTypeVariableTest.class)
                 .withClass(MyGenericService.class)
+                .withClass(RegistrationWithTypeVariableExtension.class)
                 .withBuildCompatibleExtension(RegistrationWithTypeVariableExtension.class)
                 .build();
     }


### PR DESCRIPTION
These tests should add their respective extensions into the deployment.