### PR TITLE
Add deprecated compatibility bridges for renamed assertion methods

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/AbstractTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/AbstractTest.java
@@ -15,7 +15,12 @@ package org.jboss.cdi.tck;
 
 import java.io.IOException;
 import java.lang.annotation.Annotation;
+import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import jakarta.enterprise.context.spi.Context;
@@ -106,6 +111,53 @@ public abstract class AbstractTest extends Arquillian {
 
     protected Configuration getCurrentConfiguration() {
         return ConfigurationFactory.get();
+    }
+
+    /**
+     * @deprecated Use {@link org.jboss.cdi.tck.util.Assert#assertTypesMatch(Collection, Type...)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    protected boolean typeSetMatches(Collection<? extends Type> types, Type... requiredTypes) {
+        List<Type> typeList = Arrays.asList(requiredTypes);
+        return requiredTypes.length == types.size() && types.containsAll(typeList);
+    }
+
+    /**
+     * @deprecated Use {@link org.jboss.cdi.tck.util.Assert#assertAnnotationsMatch(Collection, Class[])} instead.
+     */
+    @Deprecated(forRemoval = true)
+    protected boolean annotationSetMatches(Set<? extends Annotation> annotations,
+            Class<? extends Annotation>... requiredAnnotationTypes) {
+        Set<Class<? extends Annotation>> annotationsTypeSet = new HashSet<>();
+        for (Annotation annotation : annotations) {
+            annotationsTypeSet.add(annotation.annotationType());
+        }
+        return typeSetMatches(annotationsTypeSet, requiredAnnotationTypes);
+    }
+
+    /**
+     * @deprecated Use {@link org.jboss.cdi.tck.util.Assert#assertAnnotationsMatch(Collection, Annotation[])} instead.
+     */
+    @Deprecated(forRemoval = true)
+    protected boolean annotationSetMatches(Set<? extends Annotation> annotations, Annotation... requiredAnnotations) {
+        List<Annotation> requiredAnnotationList = Arrays.asList(requiredAnnotations);
+        return requiredAnnotations.length == annotations.size() && annotations.containsAll(requiredAnnotationList);
+    }
+
+    /**
+     * @deprecated Use {@link org.jboss.cdi.tck.util.Assert#assertTypesMatch(Collection, Type...)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    protected boolean rawTypeSetMatches(Set<Type> types, Class<?>... requiredTypes) {
+        Set<Type> typesRawSet = new HashSet<>();
+        for (Type type : types) {
+            if (type instanceof Class<?>) {
+                typesRawSet.add(type);
+            } else if (type instanceof ParameterizedType) {
+                typesRawSet.add(((ParameterizedType) type).getRawType());
+            }
+        }
+        return typeSetMatches(typesRawSet, requiredTypes);
     }
 
     protected <T> Bean<T> getUniqueBean(Class<T> type, Annotation... bindings) {

--- a/impl/src/main/java/org/jboss/cdi/tck/util/Assert.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/util/Assert.java
@@ -21,6 +21,7 @@ import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 /**
  * @author Martin Kouba
@@ -102,5 +103,13 @@ public class Assert {
             fail(String.format("Collection %s (%s) does not match array %s (%s)", types, types.size(), requiredTypeList,
                     requiredTypeList.size()));
         }
+    }
+
+    /**
+     * @deprecated Use {@link #assertTypesMatch(Collection, Type...)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    public static void assertTypeSetMatches(Set<? extends Type> types, Type... requiredTypes) {
+        assertTypesMatch(types, requiredTypes);
     }
 }


### PR DESCRIPTION
As per my comment in https://github.com/jakartaee/cdi-tck/pull/676#issuecomment-4435414321, this is what would be temporarily needed as a bridge before there is EE 12 release of platform TCKs with our changes (PR for that is https://github.com/jakartaee/platform-tck/pull/2703).

I am fine not going this way, I just created this as I was working out the cause so I though I might as well share.