### PR TITLE
Re-adding temporary release plugin configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -345,6 +345,38 @@
     </scm>
 
     <profiles>
+        <!-- Temporary profile to allow overriding central-staging-plugins version via
+             -Dcentral-staging.version=... in order to test added plugin capabilities.
+             Once the parent project inherits the required version, this can be removed. -->
+        <profile>
+            <id>override-central-staging</id>
+            <activation>
+                <property>
+                    <name>central-staging.version</name>
+                </property>
+            </activation>
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>cbi-snapshots</id>
+                    <url>https://repo.eclipse.org/content/repositories/cbi-maven2-snapshots/</url>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </pluginRepository>
+            </pluginRepositories>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.eclipse.cbi.central</groupId>
+                            <artifactId>central-staging-plugins</artifactId>
+                            <version>${central-staging.version}</version>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+
         <profile>
             <id>docs</id>
             <activation>


### PR DESCRIPTION
Found another bug in the plugin's new config option, sent a fix which was merged, now I need to try that with yet another snapshot :roll_eyes: 