### PR TITLE
Update parent `org.eclipse.ee4j:project` to 2.0.4, remove temporary profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>2.0.3</version>
+        <version>2.0.4</version>
     </parent>
 
     <!-- Metadata -->
@@ -345,38 +345,6 @@
     </scm>
 
     <profiles>
-        <!-- Temporary profile to allow overriding central-staging-plugins version via
-             -Dcentral-staging.version=... in order to test added plugin capabilities.
-             Once the parent project inherits the required version, this can be removed. -->
-        <profile>
-            <id>override-central-staging</id>
-            <activation>
-                <property>
-                    <name>central-staging.version</name>
-                </property>
-            </activation>
-            <pluginRepositories>
-                <pluginRepository>
-                    <id>cbi-snapshots</id>
-                    <url>https://repo.eclipse.org/content/repositories/cbi-maven2-snapshots/</url>
-                    <snapshots>
-                        <enabled>true</enabled>
-                    </snapshots>
-                </pluginRepository>
-            </pluginRepositories>
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <groupId>org.eclipse.cbi.central</groupId>
-                            <artifactId>central-staging-plugins</artifactId>
-                            <version>${central-staging.version}</version>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
-            </build>
-        </profile>
-
         <profile>
             <id>docs</id>
             <activation>


### PR DESCRIPTION
Same as for CDI repo - this brings in 1.4.7 release plugin version which should have the setup we need.