### PR TITLE
Replace deprecated EmailableReporter with EmailableReporter2

### DIFF
--- a/impl/src/main/resources/tck-tests.xml
+++ b/impl/src/main/resources/tck-tests.xml
@@ -11,7 +11,7 @@
         <listener class-name="org.testng.reporters.SuiteHTMLReporter"/>
         <listener class-name="org.testng.reporters.FailedReporter"/>
         <listener class-name="org.testng.reporters.XMLReporter"/>
-        <listener class-name="org.testng.reporters.EmailableReporter"/>
+        <listener class-name="org.testng.reporters.EmailableReporter2"/>
         <listener class-name="org.testng.reporters.TestHTMLReporter" />
     </listeners>
 


### PR DESCRIPTION
`EmailableReporter` was removed in TestNG 7.10+ (commit testng-team/testng@092c97d). Since the TCK uses TestNG 7.12.0, the shipped suite XML breaks any runner that consumes it. Replace with `EmailableReporter2`.

Weld PR showing the failure if the same TestNG version is used - https://github.com/weld/core/pull/3418
Sadly I didn't see this earlier as Weld was using 7.9.0 until now.