### PR TITLE
Update CDI API to 5.0.0 and fix CI staging profile

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -22,9 +22,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
-      - name: "Maven install(staging)"
-        run: |
-          mvn clean install -Dno-format -Pstaging -B -V
       - name: "Maven install"
         run: |
-          mvn clean install -Dno-format -B -V javadoc:javadoc
+          mvn clean install -Dno-format -Pstaged -B -V javadoc:javadoc

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
 
     <properties>
         <!-- CDI API -->
-        <cdi.api.version>5.0.0.CR1</cdi.api.version>
+        <cdi.api.version>5.0.0</cdi.api.version>
         <maven.compiler.release>17</maven.compiler.release>
         <!-- Jakarta EE APIs Core -->
         <annotations.api.version>3.0.0</annotations.api.version>


### PR DESCRIPTION
The `staged` profile is what's needed to work off of staged Jakarta artifacts.